### PR TITLE
Add Dev Center catalog assets and automation

### DIFF
--- a/.github/workflows/bicep-validate.yml
+++ b/.github/workflows/bicep-validate.yml
@@ -1,0 +1,34 @@
+name: Validate Bicep templates
+
+on:
+  pull_request:
+    branches:
+      - main
+  push:
+    branches:
+      - main
+
+jobs:
+  validate:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Install Bicep CLI
+        run: az bicep install
+
+      - name: Build all Bicep files
+        shell: bash
+        run: |
+          set -euo pipefail
+          mapfile -t bicep_files < <(git ls-files '*.bicep')
+          if [ ${#bicep_files[@]} -eq 0 ]; then
+            echo 'No Bicep files detected.'
+            exit 0
+          fi
+
+          for file in "${bicep_files[@]}"; do
+            echo "\nValidating ${file}"
+            az bicep build --file "$file"
+          done

--- a/.github/workflows/devcenter-catalog-sync.yml
+++ b/.github/workflows/devcenter-catalog-sync.yml
@@ -1,0 +1,46 @@
+name: Sync Dev Center catalog
+
+on:
+  push:
+    branches:
+      - main
+    paths:
+      - 'Environments/**'
+      - '.github/workflows/devcenter-catalog-sync.yml'
+  workflow_dispatch:
+
+permissions:
+  id-token: write
+  contents: read
+
+jobs:
+  sync:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Azure login
+        uses: azure/login@v1
+        with:
+          creds: ${{ secrets.AZURE_CREDENTIALS }}
+
+      - name: Ensure Dev Center CLI extension is installed
+        env:
+          AZURE_SUBSCRIPTION_ID: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
+        run: |
+          az extension add --name devcenter --upgrade
+          if [ -n "$AZURE_SUBSCRIPTION_ID" ]; then
+            az account set --subscription "$AZURE_SUBSCRIPTION_ID"
+          fi
+
+      - name: Sync catalog
+        env:
+          AZURE_DEV_CENTER_RG: ${{ secrets.AZURE_DEV_CENTER_RG }}
+          AZURE_DEV_CENTER_NAME: ${{ secrets.AZURE_DEV_CENTER_NAME }}
+          AZURE_DEV_CENTER_CATALOG_NAME: ${{ secrets.AZURE_DEV_CENTER_CATALOG_NAME }}
+        run: |
+          az devcenter admin catalog sync \
+            --name "$AZURE_DEV_CENTER_CATALOG_NAME" \
+            --resource-group "$AZURE_DEV_CENTER_RG" \
+            --dev-center-name "$AZURE_DEV_CENTER_NAME"

--- a/Environments/EnvironmentDefinitions/practx-shared-storage/environment.yaml
+++ b/Environments/EnvironmentDefinitions/practx-shared-storage/environment.yaml
@@ -1,0 +1,43 @@
+$schema: https://schema.management.azure.com/schemas/2023-10-01/EnvironmentDefinition.json
+name: practx-shared-storage
+summary: Deploys a StorageV2 account with secure defaults for Practx.io environments.
+description: |
+  Provisions a StorageV2 account tagged with the requested Dev Center environment type. Use the
+  storage account for application assets, configuration files, or other shared resources required by
+  the practx.io platform.
+runner: azureDevCenter
+templatePath: main.bicep
+parameters:
+  - id: environmentType
+    type: string
+    displayName: Environment type
+    description: Dev Center environment type this deployment is for.
+    required: true
+    allowed:
+      - DEV
+      - QA1
+      - PROD
+  - id: location
+    type: string
+    displayName: Azure region
+    description: Azure region used to deploy the environment resources.
+    required: true
+    default: eastus
+  - id: storageAccountSku
+    type: string
+    displayName: Storage SKU
+    description: Storage account redundancy tier.
+    default: Standard_LRS
+    allowed:
+      - Standard_LRS
+      - Standard_GRS
+      - Standard_RAGRS
+  - id: enableHierarchicalNamespace
+    type: boolean
+    displayName: Enable hierarchical namespace
+    description: Enables Data Lake Storage Gen2 features when true.
+    default: false
+roles:
+  - id: Contributor
+    displayName: Contributor
+    description: Grants contributors rights on the environment resource group when deployed through Dev Center.

--- a/Environments/EnvironmentDefinitions/practx-shared-storage/main.bicep
+++ b/Environments/EnvironmentDefinitions/practx-shared-storage/main.bicep
@@ -1,0 +1,47 @@
+@description('Azure region where the environment will be deployed.')
+param location string = resourceGroup().location
+
+@description('Dev Center environment type (e.g. DEV, QA1, PROD).')
+@allowed([
+  'DEV'
+  'QA1'
+  'PROD'
+])
+param environmentType string
+
+@description('Storage account SKU to provision.')
+@allowed([
+  'Standard_LRS'
+  'Standard_GRS'
+  'Standard_RAGRS'
+])
+param storageAccountSku string = 'Standard_LRS'
+
+@description('Enable the hierarchical namespace for Data Lake Gen2 workloads.')
+param enableHierarchicalNamespace bool = false
+
+var storageAccountName = toLower('practx${uniqueString(resourceGroup().id, environmentType)}')
+
+resource storageAccount 'Microsoft.Storage/storageAccounts@2023-01-01' = {
+  name: storageAccountName
+  location: location
+  sku: {
+    name: storageAccountSku
+  }
+  kind: 'StorageV2'
+  properties: {
+    accessTier: 'Hot'
+    allowBlobPublicAccess: false
+    minimumTlsVersion: 'TLS1_2'
+    supportsHttpsTrafficOnly: true
+    allowSharedKeyAccess: true
+    isHnsEnabled: enableHierarchicalNamespace
+  }
+  tags: {
+    'practx.io:environmentType': environmentType
+    'practx.io:managedBy': 'Azure Dev Center'
+  }
+}
+
+output storageAccountResourceId string = storageAccount.id
+output storageAccountName string = storageAccount.name

--- a/Environments/README.md
+++ b/Environments/README.md
@@ -1,0 +1,22 @@
+# Azure Dev Center Catalog
+
+This folder hosts the Azure Dev Center catalog artifacts for practx.io.  Azure Dev Center reads the
+contents of `EnvironmentDefinitions/` to expose self-service environments for engineering teams.  The
+catalog is synchronized automatically from the `main` branch.
+
+```
+Environments/
+├─ EnvironmentDefinitions/
+│  └─ practx-shared-storage/
+│     ├─ environment.yaml   # Definition manifest consumed by Azure Dev Center
+│     └─ main.bicep         # Infrastructure template deployed by the catalog
+└─ README.md
+```
+
+Add new environment definitions by creating a new folder under `EnvironmentDefinitions/` that
+contains at minimum an `environment.yaml` manifest and the referenced infrastructure template (Bicep
+or ARM).  The GitHub Actions and Azure DevOps pipelines will lint every `*.bicep` file in the repo and
+must succeed before a pull request can be merged.
+
+> ℹ️ The Dev Center environments for this project are `DEV`, `QA1`, and `PROD`.  Environment
+> definitions should scope inputs and policy to those types when appropriate.

--- a/README.md
+++ b/README.md
@@ -4,6 +4,24 @@ This repository bootstraps the practx.io platform. It includes the Next.js web e
 
 Hosted in Git, there is CICD integration with Azure Dev Center, if it works.
 
+## Azure Dev Center catalog
+
+The [`Environments/`](Environments/README.md) folder contains the Azure Dev Center catalog used to
+provision DEV, QA1, and PROD environments.  Each environment definition is made up of an
+`environment.yaml` manifest plus the referenced Bicep template.  GitHub Actions validate every Bicep
+file on pull requests and `main` pushes, and the catalog automatically synchronizes whenever
+`Environments/**` changes on `main`.
+
+To add a new environment definition:
+
+1. Create a folder under `Environments/EnvironmentDefinitions/` with an `environment.yaml` manifest
+   and a Bicep template.
+2. Update documentation as needed.
+3. Open a pull request; the Bicep validation workflow must pass.
+4. Merge to `main` to trigger a catalog sync via the Dev Center GitHub Action.
+
+Secrets required by the workflows are detailed in the **Dev Center automation** section below.
+
 ## Structure
 
 ```
@@ -35,3 +53,30 @@ practix/
 5. Seed the SQL database with `schemas/sql/001_core.sql` (and optional seed data) before running the app.
 
 Refer to the spec for full acceptance criteria: registration via B2C, Stripe paywall gating the `/elm` workspace, SQL persistence, APIM entitlement enforcement, and logging via Application Insights.
+
+## Dev Center automation
+
+Two automations support the Dev Center experience:
+
+| Workflow | Trigger | Purpose |
+| --- | --- | --- |
+| `.github/workflows/bicep-validate.yml` | Pull requests and pushes to `main` | Ensures every Bicep template in the repo builds successfully. |
+| `.github/workflows/devcenter-catalog-sync.yml` | Push to `main` that touches `Environments/**` | Uses the Azure Dev Center admin API to sync the catalog. |
+
+### Required GitHub secrets / variables
+
+| Name | Type | Description |
+| --- | --- | --- |
+| `AZURE_CREDENTIALS` | secret | Output of `az ad sp create-for-rbac` with access to the Dev Center resource group. |
+| `AZURE_SUBSCRIPTION_ID` | secret or variable | Subscription that hosts the Dev Center. |
+| `AZURE_DEV_CENTER_RG` | secret or variable | Resource group for the Dev Center (`<RG_NAME>`). |
+| `AZURE_DEV_CENTER_NAME` | secret or variable | Dev Center resource name (`<DEV_CENTER_NAME>`). |
+| `AZURE_DEV_CENTER_CATALOG_NAME` | secret or variable | Catalog resource name (`<CATALOG_NAME>`). |
+
+The catalog sync workflow logs in with `AZURE_CREDENTIALS`, installs the Dev Center CLI extension, and
+invokes `az devcenter admin catalog sync` using the remaining variables.
+
+### Azure DevOps pipeline
+
+An equivalent Azure Pipelines definition is available at
+`practix/.ado/pipelines/environment-catalog-ci.yml` for teams running CI/CD in Azure DevOps.

--- a/practix/.ado/pipelines/environment-catalog-ci.yml
+++ b/practix/.ado/pipelines/environment-catalog-ci.yml
@@ -1,0 +1,33 @@
+trigger:
+  branches:
+    include:
+      - main
+
+pr:
+  branches:
+    include:
+      - main
+
+pool:
+  vmImage: 'ubuntu-latest'
+
+steps:
+  - checkout: self
+
+  - task: Bash@3
+    displayName: Validate Bicep templates
+    inputs:
+      targetType: inline
+      script: |
+        set -euo pipefail
+        az bicep install
+        files=$(git ls-files '*.bicep')
+        if [ -z "$files" ]; then
+          echo 'No Bicep files detected.'
+          exit 0
+        fi
+
+        for file in $files; do
+          echo "Validating $file"
+          az bicep build --file "$file"
+        done

--- a/practix/infra/modules/keyvault.bicep
+++ b/practix/infra/modules/keyvault.bicep
@@ -1,5 +1,6 @@
 param name string
 param location string
+@secure()
 param secrets object
 
 resource keyVault 'Microsoft.KeyVault/vaults@2022-07-01' = {
@@ -17,10 +18,10 @@ resource keyVault 'Microsoft.KeyVault/vaults@2022-07-01' = {
   }
 }
 
-resource secretResources 'Microsoft.KeyVault/vaults/secrets@2022-07-01' = [for secretName in union([], keys(secrets)) : {
-  name: '${keyVault.name}/${secretName}'
+resource secretResources 'Microsoft.KeyVault/vaults/secrets@2022-07-01' = [for secret in items(secrets) : {
+  name: '${keyVault.name}/${secret.key}'
   properties: {
-    value: secrets[secretName]
+    value: secret.value
   }
 }]
 


### PR DESCRIPTION
## Summary
- add an `Environments/` catalog scaffold with a practx-shared-storage environment definition
- document how to work with the catalog and required secrets for automation
- add GitHub Actions and Azure Pipelines jobs for Bicep validation plus catalog syncing
- fix the key vault module secret loop so existing Bicep templates compile

## Testing
- bicep build practix/infra/main.bicep
- bicep build Environments/EnvironmentDefinitions/practx-shared-storage/main.bicep

------
https://chatgpt.com/codex/tasks/task_e_68d2974b8d1c832393b611a856e11db5