### PR TITLE
Add Dev Center environment definitions for Practx services

### DIFF
--- a/Environments/EnvironmentDefinitions/practx-apim/environment.yaml
+++ b/Environments/EnvironmentDefinitions/practx-apim/environment.yaml
@@ -1,0 +1,40 @@
+# yaml-language-server: $schema=https://github.com/Azure/deployment-environments/releases/download/2022-11-11-preview/manifest.schema.json
+
+name: practx-apim
+summary: Deploys an Azure API Management instance with the Practx.io entitlement policy.
+description: |
+  Creates an Azure API Management Developer SKU instance and publishes the Practx API with the shared
+  entitlement validation policy. Optionally override the policy with a custom XML document at deployment
+  time.
+
+runner: Bicep
+templatePath: main.bicep
+
+parameters:
+  - id: environmentType
+    name: Environment type
+    type: string
+    description: Dev Center environment type this deployment is for.
+    required: true
+    allowed:
+      - DEV
+      - QA1
+      - PROD
+
+  - id: location
+    name: Azure region
+    type: string
+    description: Azure region used to deploy the environment resources.
+    default: westus2
+
+  - id: baseName
+    name: Resource base name
+    type: string
+    description: Base name combined with the environment type to create resource names.
+    default: practx
+
+  - id: policyOverride
+    name: Custom policy XML
+    type: string
+    description: Optional XML document that replaces the default entitlement validation policy.
+    default: ""

--- a/Environments/EnvironmentDefinitions/practx-apim/main.bicep
+++ b/Environments/EnvironmentDefinitions/practx-apim/main.bicep
@@ -1,0 +1,31 @@
+@description('Azure region where the environment will be deployed.')
+param location string = resourceGroup().location
+
+@description('Dev Center environment type (e.g. DEV, QA1, PROD).')
+@allowed([
+  'DEV'
+  'QA1'
+  'PROD'
+])
+param environmentType string
+
+@description('Base name used to build resource names.')
+param baseName string = 'practx'
+
+@description('Optional XML document that overrides the default entitlement validation policy.')
+param policyOverride string = ''
+
+var namePrefix = toLower('${baseName}-${environmentType}')
+var defaultPolicy = loadTextContent('../../../practix/apim/policies/check-entitlement.xml')
+var policyContent = empty(policyOverride) ? defaultPolicy : policyOverride
+
+module apim '../../../practix/infra/modules/apim.bicep' = {
+  name: '${namePrefix}-apim'
+  params: {
+    namePrefix: namePrefix
+    location: location
+    policyContent: policyContent
+  }
+}
+
+output apiManagementName string = apim.outputs.apimName

--- a/Environments/EnvironmentDefinitions/practx-application-insights/environment.yaml
+++ b/Environments/EnvironmentDefinitions/practx-application-insights/environment.yaml
@@ -1,0 +1,34 @@
+# yaml-language-server: $schema=https://github.com/Azure/deployment-environments/releases/download/2022-11-11-preview/manifest.schema.json
+
+name: practx-application-insights
+summary: Deploys an Application Insights instance for Practx.io workloads.
+description: |
+  Provisions an Application Insights component configured for web workloads so teams can instrument
+  Practx.io services. The deployment returns both the instrumentation key and connection string for
+  downstream integrations.
+
+runner: Bicep
+templatePath: main.bicep
+
+parameters:
+  - id: environmentType
+    name: Environment type
+    type: string
+    description: Dev Center environment type this deployment is for.
+    required: true
+    allowed:
+      - DEV
+      - QA1
+      - PROD
+
+  - id: location
+    name: Azure region
+    type: string
+    description: Azure region used to deploy the environment resources.
+    default: westus2
+
+  - id: baseName
+    name: Resource base name
+    type: string
+    description: Base name combined with the environment type to create resource names.
+    default: practx

--- a/Environments/EnvironmentDefinitions/practx-application-insights/main.bicep
+++ b/Environments/EnvironmentDefinitions/practx-application-insights/main.bicep
@@ -1,0 +1,28 @@
+@description('Azure region where the environment will be deployed.')
+param location string = resourceGroup().location
+
+@description('Dev Center environment type (e.g. DEV, QA1, PROD).')
+@allowed([
+  'DEV'
+  'QA1'
+  'PROD'
+])
+param environmentType string
+
+@description('Base name used to build resource names.')
+param baseName string = 'practx'
+
+var namePrefix = toLower('${baseName}-${environmentType}')
+var insightsName = '${namePrefix}-appi'
+
+module insights '../../../practix/infra/modules/insights.bicep' = {
+  name: '${namePrefix}-insights'
+  params: {
+    name: insightsName
+    location: location
+  }
+}
+
+output applicationInsightsName string = insightsName
+output instrumentationKey string = insights.outputs.instrumentationKey
+output connectionString string = insights.outputs.connectionString

--- a/Environments/EnvironmentDefinitions/practx-appservice/environment.yaml
+++ b/Environments/EnvironmentDefinitions/practx-appservice/environment.yaml
@@ -1,0 +1,53 @@
+# yaml-language-server: $schema=https://github.com/Azure/deployment-environments/releases/download/2022-11-11-preview/manifest.schema.json
+
+name: practx-appservice
+summary: Deploys a Linux App Service plan hosting the Practx.io web and API applications.
+description: |
+  Creates a Premium v3 Linux App Service plan along with paired web and API applications configured for
+  Practx.io. The apps are wired to Application Insights and retrieve secrets from an existing Key Vault
+  using system-assigned managed identities.
+
+runner: Bicep
+templatePath: main.bicep
+
+parameters:
+  - id: environmentType
+    name: Environment type
+    type: string
+    description: Dev Center environment type this deployment is for.
+    required: true
+    allowed:
+      - DEV
+      - QA1
+      - PROD
+
+  - id: location
+    name: Azure region
+    type: string
+    description: Azure region used to deploy the environment resources.
+    default: westus2
+
+  - id: baseName
+    name: Resource base name
+    type: string
+    description: Base name combined with the environment type to create resource names.
+    default: practx
+
+  - id: keyVaultId
+    name: Key Vault resource ID
+    type: string
+    description: Resource ID for the Key Vault that stores application secrets.
+    required: true
+
+  - id: keyVaultName
+    name: Key Vault name
+    type: string
+    description: Name of the Key Vault that stores application secrets.
+    required: true
+
+  - id: appInsightsConnectionString
+    name: Application Insights connection string
+    type: string
+    description: Connection string used to emit telemetry.
+    required: true
+    secure: true

--- a/Environments/EnvironmentDefinitions/practx-appservice/main.bicep
+++ b/Environments/EnvironmentDefinitions/practx-appservice/main.bicep
@@ -1,0 +1,40 @@
+@description('Azure region where the environment will be deployed.')
+param location string = resourceGroup().location
+
+@description('Dev Center environment type (e.g. DEV, QA1, PROD).')
+@allowed([
+  'DEV'
+  'QA1'
+  'PROD'
+])
+param environmentType string
+
+@description('Base name used to build resource names.')
+param baseName string = 'practx'
+
+@description('Resource ID for the Key Vault that stores application secrets.')
+param keyVaultId string
+
+@description('Name of the Key Vault that stores application secrets.')
+param keyVaultName string
+
+@description('Application Insights connection string used by the apps.')
+@secure()
+param appInsightsConnectionString string
+
+var namePrefix = toLower('${baseName}-${environmentType}')
+
+module appService '../../../practix/infra/modules/appservice.bicep' = {
+  name: '${namePrefix}-apps'
+  params: {
+    namePrefix: namePrefix
+    location: location
+    keyVaultId: keyVaultId
+    keyVaultName: keyVaultName
+    insightsConnectionString: appInsightsConnectionString
+  }
+}
+
+output webAppName string = appService.outputs.webAppName
+output apiAppName string = appService.outputs.apiAppName
+output planResourceId string = appService.outputs.planId

--- a/Environments/EnvironmentDefinitions/practx-functions/environment.yaml
+++ b/Environments/EnvironmentDefinitions/practx-functions/environment.yaml
@@ -1,0 +1,59 @@
+# yaml-language-server: $schema=https://github.com/Azure/deployment-environments/releases/download/2022-11-11-preview/manifest.schema.json
+
+name: practx-functions
+summary: Deploys a consumption-based Azure Functions app for Practx.io background processing.
+description: |
+  Creates an event-driven Azure Functions app on the Dynamic (Y1) plan configured for Practx.io. The
+  deployment wires the app to Application Insights, an existing storage account, and the shared Key Vault
+  that provides required application secrets.
+
+runner: Bicep
+templatePath: main.bicep
+
+parameters:
+  - id: environmentType
+    name: Environment type
+    type: string
+    description: Dev Center environment type this deployment is for.
+    required: true
+    allowed:
+      - DEV
+      - QA1
+      - PROD
+
+  - id: location
+    name: Azure region
+    type: string
+    description: Azure region used to deploy the environment resources.
+    default: westus2
+
+  - id: baseName
+    name: Resource base name
+    type: string
+    description: Base name combined with the environment type to create resource names.
+    default: practx
+
+  - id: storageAccountName
+    name: Storage account name
+    type: string
+    description: Name of the storage account used for the Functions runtime.
+    required: true
+
+  - id: appInsightsConnectionString
+    name: Application Insights connection string
+    type: string
+    description: Connection string used to emit telemetry.
+    required: true
+    secure: true
+
+  - id: keyVaultId
+    name: Key Vault resource ID
+    type: string
+    description: Resource ID for the Key Vault that stores application secrets.
+    required: true
+
+  - id: keyVaultName
+    name: Key Vault name
+    type: string
+    description: Name of the Key Vault that stores application secrets.
+    required: true

--- a/Environments/EnvironmentDefinitions/practx-functions/main.bicep
+++ b/Environments/EnvironmentDefinitions/practx-functions/main.bicep
@@ -1,0 +1,43 @@
+@description('Azure region where the environment will be deployed.')
+param location string = resourceGroup().location
+
+@description('Dev Center environment type (e.g. DEV, QA1, PROD).')
+@allowed([
+  'DEV'
+  'QA1'
+  'PROD'
+])
+param environmentType string
+
+@description('Base name used to build resource names.')
+param baseName string = 'practx'
+
+@description('Name of the storage account used for the Functions runtime.')
+param storageAccountName string
+
+@description('Application Insights connection string used by the function app.')
+@secure()
+param appInsightsConnectionString string
+
+@description('Resource ID for the Key Vault that stores application secrets.')
+param keyVaultId string
+
+@description('Name of the Key Vault that stores application secrets.')
+param keyVaultName string
+
+var namePrefix = toLower('${baseName}-${environmentType}')
+
+module functions '../../../practix/infra/modules/functions.bicep' = {
+  name: '${namePrefix}-fn'
+  params: {
+    namePrefix: namePrefix
+    location: location
+    storageAccountName: storageAccountName
+    appInsightsConnectionString: appInsightsConnectionString
+    keyVaultId: keyVaultId
+    keyVaultName: keyVaultName
+  }
+}
+
+output functionAppName string = functions.outputs.functionAppName
+output planResourceId string = functions.outputs.planId

--- a/Environments/EnvironmentDefinitions/practx-keyvault/environment.yaml
+++ b/Environments/EnvironmentDefinitions/practx-keyvault/environment.yaml
@@ -1,0 +1,92 @@
+# yaml-language-server: $schema=https://github.com/Azure/deployment-environments/releases/download/2022-11-11-preview/manifest.schema.json
+
+name: practx-keyvault
+summary: Deploys an Azure Key Vault pre-populated with Practx.io application secrets.
+description: |
+  Creates an Azure Key Vault secured with RBAC authorization and seeds it with the application secrets
+  required by Practx.io services. Supply the application secrets as parameters so dependent services can
+  retrieve them by name after deployment.
+
+runner: Bicep
+templatePath: main.bicep
+
+parameters:
+  - id: environmentType
+    name: Environment type
+    type: string
+    description: Dev Center environment type this deployment is for.
+    required: true
+    allowed:
+      - DEV
+      - QA1
+      - PROD
+
+  - id: location
+    name: Azure region
+    type: string
+    description: Azure region used to deploy the environment resources.
+    default: westus2
+
+  - id: baseName
+    name: Resource base name
+    type: string
+    description: Base name combined with the environment type to create resource names.
+    default: practx
+
+  - id: sqlConnectionString
+    name: SQL connection string
+    type: string
+    description: Connection string seeded into the SQLCONN secret.
+    required: true
+    secure: true
+
+  - id: stripeSecretKey
+    name: Stripe secret key
+    type: string
+    description: Secret key for Stripe API calls.
+    required: true
+    secure: true
+
+  - id: stripePublicKey
+    name: Stripe publishable key
+    type: string
+    description: Publishable key for Stripe client integrations.
+    required: true
+
+  - id: stripePriceId
+    name: Stripe price identifier
+    type: string
+    description: Price ID referenced by billing workflows.
+    required: true
+
+  - id: stripeWebhookSecret
+    name: Stripe webhook signing secret
+    type: string
+    description: Secret used to validate Stripe webhook signatures.
+    required: true
+    secure: true
+
+  - id: b2cTenant
+    name: Entra External ID (B2C) tenant name
+    type: string
+    description: Name of the Entra External ID tenant used for authentication.
+    required: true
+
+  - id: b2cClientId
+    name: Entra External ID (B2C) client ID
+    type: string
+    description: Client application ID for Entra External ID authentication.
+    required: true
+
+  - id: b2cSignInPolicy
+    name: Entra External ID (B2C) sign-in policy
+    type: string
+    description: User flow or custom policy identifier for sign-in.
+    required: true
+
+  - id: storageConnectionString
+    name: Storage connection string
+    type: string
+    description: Connection string stored as STORAGE_CONNECTION.
+    required: true
+    secure: true

--- a/Environments/EnvironmentDefinitions/practx-keyvault/main.bicep
+++ b/Environments/EnvironmentDefinitions/practx-keyvault/main.bicep
@@ -1,0 +1,70 @@
+@description('Azure region where the environment will be deployed.')
+param location string = resourceGroup().location
+
+@description('Dev Center environment type (e.g. DEV, QA1, PROD).')
+@allowed([
+  'DEV'
+  'QA1'
+  'PROD'
+])
+param environmentType string
+
+@description('Base name used to build resource names.')
+param baseName string = 'practx'
+
+@description('SQL connection string seeded into the Key Vault.')
+@secure()
+param sqlConnectionString string
+
+@description('Stripe secret key stored in the Key Vault.')
+@secure()
+param stripeSecretKey string
+
+@description('Stripe publishable key stored in the Key Vault.')
+param stripePublicKey string
+
+@description('Stripe price identifier stored in the Key Vault.')
+param stripePriceId string
+
+@description('Stripe webhook signing secret stored in the Key Vault.')
+@secure()
+param stripeWebhookSecret string
+
+@description('Entra External ID tenant name stored in the Key Vault.')
+param b2cTenant string
+
+@description('Entra External ID client ID stored in the Key Vault.')
+param b2cClientId string
+
+@description('Entra External ID sign-in policy stored in the Key Vault.')
+param b2cSignInPolicy string
+
+@description('Storage connection string stored in the Key Vault.')
+@secure()
+param storageConnectionString string
+
+var namePrefix = toLower('${baseName}-${environmentType}')
+var keyVaultName = replace('${namePrefix}-kv', '-', '')
+
+module keyVault '../../../practix/infra/modules/keyvault.bicep' = {
+  name: '${namePrefix}-kv'
+  params: {
+    name: keyVaultName
+    location: location
+    secrets: {
+      SQLCONN: sqlConnectionString
+      STRIPE_SECRET_KEY: stripeSecretKey
+      STRIPE_PUBLIC_KEY: stripePublicKey
+      STRIPE_PRICE_ID: stripePriceId
+      STRIPE_WEBHOOK_SECRET: stripeWebhookSecret
+      B2C_TENANT: b2cTenant
+      B2C_CLIENT_ID: b2cClientId
+      B2C_SIGNIN_POLICY: b2cSignInPolicy
+      STORAGE_CONNECTION: storageConnectionString
+    }
+  }
+}
+
+output keyVaultName string = keyVault.outputs.keyVaultName
+output keyVaultId string = keyVault.outputs.keyVaultId
+output keyVaultUri string = keyVault.outputs.keyVaultUri

--- a/Environments/EnvironmentDefinitions/practx-sql/environment.yaml
+++ b/Environments/EnvironmentDefinitions/practx-sql/environment.yaml
@@ -1,0 +1,47 @@
+# yaml-language-server: $schema=https://github.com/Azure/deployment-environments/releases/download/2022-11-11-preview/manifest.schema.json
+
+name: practx-sql
+summary: Deploys an Azure SQL Server and elastic database for Practx.io environments.
+description: |
+  Provisions an Azure SQL Server with a General Purpose database sized for development and test workloads.
+  Provide administrator credentials to manage the instance and retrieve the generated connection string
+  from the deployment outputs for downstream services.
+
+runner: Bicep
+templatePath: main.bicep
+
+parameters:
+  - id: environmentType
+    name: Environment type
+    type: string
+    description: Dev Center environment type this deployment is for.
+    required: true
+    allowed:
+      - DEV
+      - QA1
+      - PROD
+
+  - id: location
+    name: Azure region
+    type: string
+    description: Azure region used to deploy the environment resources.
+    default: westus2
+
+  - id: baseName
+    name: Resource base name
+    type: string
+    description: Base name combined with the environment type to create resource names.
+    default: practx
+
+  - id: sqlAdminLogin
+    name: SQL administrator login
+    type: string
+    description: Login name for the SQL administrator account.
+    required: true
+
+  - id: sqlAdminPassword
+    name: SQL administrator password
+    type: string
+    description: Password for the SQL administrator account.
+    required: true
+    secure: true

--- a/Environments/EnvironmentDefinitions/practx-sql/main.bicep
+++ b/Environments/EnvironmentDefinitions/practx-sql/main.bicep
@@ -1,0 +1,36 @@
+@description('Azure region where the environment will be deployed.')
+param location string = resourceGroup().location
+
+@description('Dev Center environment type (e.g. DEV, QA1, PROD).')
+@allowed([
+  'DEV'
+  'QA1'
+  'PROD'
+])
+param environmentType string
+
+@description('Base name used to build resource names.')
+param baseName string = 'practx'
+
+@description('Administrator login for the SQL Server instance.')
+param sqlAdminLogin string
+
+@description('Administrator password for the SQL Server instance.')
+@secure()
+param sqlAdminPassword string
+
+var namePrefix = toLower('${baseName}-${environmentType}')
+
+module sql '../../../practix/infra/modules/sql.bicep' = {
+  name: '${namePrefix}-sql'
+  params: {
+    namePrefix: namePrefix
+    location: location
+    adminLogin: sqlAdminLogin
+    adminPassword: sqlAdminPassword
+  }
+}
+
+output sqlServerName string = sql.outputs.serverName
+output databaseName string = sql.outputs.databaseName
+output connectionString string = sql.outputs.connectionString


### PR DESCRIPTION
## Summary
- add Azure Deployment Environment manifests for Application Insights, SQL, Key Vault, App Service, Functions, and API Management resources
- wire the definitions to existing Bicep modules and surface the parameters and outputs needed by dependent services

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d5294479c48323ba3a8411720b5a60