### PR TITLE
Add consolidated dev-platform environment and Bicep validation

### DIFF
--- a/.github/workflows/validate-bicep.yml
+++ b/.github/workflows/validate-bicep.yml
@@ -1,0 +1,60 @@
+name: Validate Bicep templates
+
+on:
+  push:
+    branches: [ main ]
+    paths:
+      - '**/*.bicep'
+  pull_request:
+    branches: [ main ]
+    paths:
+      - '**/*.bicep'
+
+jobs:
+  validate:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Install Azure CLI
+        uses: azure/setup-azure@v4
+
+      - name: Install Bicep CLI
+        run: az bicep install
+
+      - name: Find changed .bicep files
+        id: changes
+        shell: bash
+        run: |
+          set -euo pipefail
+          if [[ "${GITHUB_EVENT_NAME}" == "pull_request" ]]; then
+            BASE="${{ github.event.pull_request.base.sha }}"
+          else
+            BASE="${{ github.event.before }}"
+          fi
+          HEAD="${GITHUB_SHA}"
+          git fetch --no-tags --prune --progress --depth=0 origin +${BASE}:${BASE} || true
+          git fetch --no-tags --prune --progress --depth=0 origin +${HEAD}:${HEAD} || true
+          mapfile -t CHANGED < <(git diff --name-only --diff-filter=ACMR "${BASE}..${HEAD}" | grep -E '\.bicep$' || true)
+          if (( ${#CHANGED[@]} == 0 )); then
+            echo "No changed .bicep files detected."
+            echo "count=0" >> "$GITHUB_OUTPUT"
+          else
+            printf 'files<<EOF\n' >> "$GITHUB_OUTPUT"
+            printf '%s\n' "${CHANGED[@]}" >> "$GITHUB_OUTPUT"
+            printf 'EOF\n' >> "$GITHUB_OUTPUT"
+            echo "count=${#CHANGED[@]}" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Build changed Bicep files
+        if: steps.changes.outputs.count != '0'
+        shell: bash
+        run: |
+          set -euo pipefail
+          while IFS= read -r file; do
+            echo "Validating ${file}"
+            az bicep build --file "$file"
+          done <<< "${{ steps.changes.outputs.files || '' }}"

--- a/Environments/EnvironmentDefinitions/practx-shared-storage/main.bicep
+++ b/Environments/EnvironmentDefinitions/practx-shared-storage/main.bicep
@@ -38,6 +38,7 @@ resource storageAccount 'Microsoft.Storage/storageAccounts@2023-01-01' = {
     isHnsEnabled: enableHierarchicalNamespace
   }
   tags: {
+    'EnvironmentType': environmentType
     'practx.io:environmentType': environmentType
     'practx.io:managedBy': 'Azure Dev Center'
   }

--- a/Environments/dev-platform/environment.yml
+++ b/Environments/dev-platform/environment.yml
@@ -1,0 +1,67 @@
+$schema: https://schema.management.azure.com/schemas/2023-10-01/EnvironmentDefinition.json
+name: dev-platform
+summary: DEV platform baseline (aggregated resources)
+description: Deploys the DEV environment as a single atomic environment via Azure Deployment Environments.
+runner: azureDevCenter
+# Parent template is in the same folder:
+templatePath: ./main.bicep
+parameters:
+  - id: environmentType
+    type: string
+    displayName: Environment type
+    description: Must match a Dev Center Environment Type (e.g., DEV/QA1/PROD).
+    required: true
+    default: DEV
+  - id: location
+    type: string
+    displayName: Azure region
+    required: true
+    default: eastus
+  - id: sqlAdminLogin
+    type: string
+    displayName: SQL administrator login
+    description: Login name used for the SQL Server administrator account.
+    required: true
+  - id: sqlAdminPassword
+    type: string
+    displayName: SQL administrator password
+    description: Password used for the SQL Server administrator account.
+    required: true
+    secret: true
+  - id: stripeSecretKey
+    type: string
+    displayName: Stripe secret key
+    description: Secret key injected into the Key Vault (SQLCONN, Stripe, and storage secrets are required).
+    required: true
+    secret: true
+  - id: stripePublicKey
+    type: string
+    displayName: Stripe publishable key
+    required: true
+  - id: stripePriceId
+    type: string
+    displayName: Stripe price identifier
+    required: true
+  - id: stripeWebhookSecret
+    type: string
+    displayName: Stripe webhook secret
+    required: true
+    secret: true
+  - id: b2cTenant
+    type: string
+    displayName: Entra External ID tenant name
+    required: true
+  - id: b2cClientId
+    type: string
+    displayName: Entra External ID client ID
+    required: true
+  - id: b2cSignInPolicy
+    type: string
+    displayName: Entra External ID sign-in policy
+    required: true
+  - id: storageConnectionString
+    type: string
+    displayName: Storage connection string
+    description: Connection string stored in the Key Vault as STORAGE_CONNECTION.
+    required: true
+    secret: true

--- a/Environments/dev-platform/main.bicep
+++ b/Environments/dev-platform/main.bicep
@@ -1,0 +1,131 @@
+@description('Azure region')
+param location string = 'eastus'
+
+@description('Environment type tag, e.g., DEV/QA1/PROD')
+param environmentType string = 'DEV'
+
+@description('SQL administrator login for the SQL Server instance.')
+param sqlAdminLogin string
+
+@description('SQL administrator password for the SQL Server instance.')
+@secure()
+param sqlAdminPassword string
+
+@description('Stripe secret key stored in the Key Vault.')
+@secure()
+param stripeSecretKey string
+
+@description('Stripe publishable key stored in the Key Vault.')
+param stripePublicKey string
+
+@description('Stripe price identifier stored in the Key Vault.')
+param stripePriceId string
+
+@description('Stripe webhook signing secret stored in the Key Vault.')
+@secure()
+param stripeWebhookSecret string
+
+@description('Entra External ID tenant name stored in the Key Vault.')
+param b2cTenant string
+
+@description('Entra External ID client ID stored in the Key Vault.')
+param b2cClientId string
+
+@description('Entra External ID sign-in policy stored in the Key Vault.')
+param b2cSignInPolicy string
+
+@description('Storage connection string stored in the Key Vault.')
+@secure()
+param storageConnectionString string
+
+// Modules auto-discovered from Environments/EnvironmentDefinitions/practx-*/main.bicep
+module sharedStorage '../EnvironmentDefinitions/practx-shared-storage/main.bicep' = {
+  name: 'sharedStorage'
+  params: {
+    location: location
+    environmentType: environmentType
+  }
+}
+
+module sql '../EnvironmentDefinitions/practx-sql/main.bicep' = {
+  name: 'sql'
+  params: {
+    location: location
+    environmentType: environmentType
+    sqlAdminLogin: sqlAdminLogin
+    sqlAdminPassword: sqlAdminPassword
+  }
+}
+
+module applicationInsights '../EnvironmentDefinitions/practx-application-insights/main.bicep' = {
+  name: 'applicationInsights'
+  params: {
+    location: location
+    environmentType: environmentType
+  }
+}
+
+module keyvault '../EnvironmentDefinitions/practx-keyvault/main.bicep' = {
+  name: 'keyvault'
+  params: {
+    location: location
+    environmentType: environmentType
+    sqlConnectionString: sql.outputs.connectionString
+    stripeSecretKey: stripeSecretKey
+    stripePublicKey: stripePublicKey
+    stripePriceId: stripePriceId
+    stripeWebhookSecret: stripeWebhookSecret
+    b2cTenant: b2cTenant
+    b2cClientId: b2cClientId
+    b2cSignInPolicy: b2cSignInPolicy
+    storageConnectionString: storageConnectionString
+  }
+}
+
+module functions '../EnvironmentDefinitions/practx-functions/main.bicep' = {
+  name: 'functions'
+  params: {
+    location: location
+    environmentType: environmentType
+    storageAccountName: sharedStorage.outputs.storageAccountName
+    appInsightsConnectionString: applicationInsights.outputs.connectionString
+    keyVaultId: keyvault.outputs.keyVaultId
+    keyVaultName: keyvault.outputs.keyVaultName
+  }
+}
+
+module appservice '../EnvironmentDefinitions/practx-appservice/main.bicep' = {
+  name: 'appservice'
+  params: {
+    location: location
+    environmentType: environmentType
+    keyVaultId: keyvault.outputs.keyVaultId
+    keyVaultName: keyvault.outputs.keyVaultName
+    appInsightsConnectionString: applicationInsights.outputs.connectionString
+  }
+}
+
+module apim '../EnvironmentDefinitions/practx-apim/main.bicep' = {
+  name: 'apim'
+  params: {
+    location: location
+    environmentType: environmentType
+  }
+}
+
+output apiManagementName string = apim.outputs.apiManagementName
+output applicationInsightsName string = applicationInsights.outputs.applicationInsightsName
+output applicationInsightsConnectionString string = applicationInsights.outputs.connectionString
+output keyVaultName string = keyvault.outputs.keyVaultName
+output keyVaultId string = keyvault.outputs.keyVaultId
+output keyVaultUri string = keyvault.outputs.keyVaultUri
+output storageAccountName string = sharedStorage.outputs.storageAccountName
+output storageAccountResourceId string = sharedStorage.outputs.storageAccountResourceId
+output sqlServerName string = sql.outputs.sqlServerName
+output sqlDatabaseName string = sql.outputs.databaseName
+output sqlConnectionString string = sql.outputs.connectionString
+output webAppName string = appservice.outputs.webAppName
+output apiAppName string = appservice.outputs.apiAppName
+output appServicePlanResourceId string = appservice.outputs.planResourceId
+output functionAppName string = functions.outputs.functionAppName
+output functionPlanResourceId string = functions.outputs.planResourceId


### PR DESCRIPTION
## Summary
- add a dev-platform catalog entry that wires together all practx-* resource modules into a single deployment
- ensure shared storage resources carry the EnvironmentType tag and expose the new environment manifest
- add a workflow that validates only modified Bicep templates in CI

## Testing
- az bicep build --file Environments/dev-platform/main.bicep
- az bicep build --file Environments/EnvironmentDefinitions/practx-apim/main.bicep
- az bicep build --file Environments/EnvironmentDefinitions/practx-application-insights/main.bicep
- az bicep build --file Environments/EnvironmentDefinitions/practx-appservice/main.bicep
- az bicep build --file Environments/EnvironmentDefinitions/practx-functions/main.bicep
- az bicep build --file Environments/EnvironmentDefinitions/practx-keyvault/main.bicep
- az bicep build --file Environments/EnvironmentDefinitions/practx-shared-storage/main.bicep
- az bicep build --file Environments/EnvironmentDefinitions/practx-sql/main.bicep

------
https://chatgpt.com/codex/tasks/task_e_68d7d632c2488323a570274bcb487d03