### PR TITLE
Add Azure DevOps pipelines for infrastructure and static site

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,8 +4,15 @@ This repository bootstraps the practx.io platform. It includes the Next.js web e
 
 Hosted in Git, there is CICD integration with Azure Dev Center, if it works.
 
+## Deployment paths
+
+- **GitHub + Azure Dev Center** – the original workflow that syncs the `Environments/` catalog and lets developers self-serve environments from the Developer Portal.
+- **GitHub only (no Dev Center)** – run the Bicep templates directly with the Azure CLI and keep shipping the Static Web App through GitHub Actions. See [Using GitHub Without Azure Dev Center](docs/github-without-devcenter.md).
+- **Azure DevOps pipelines** – reuse the YAML definitions under `pipelines/` to validate and deploy infrastructure or publish the Static Web App from Azure DevOps. Details live in [Azure DevOps Pipelines for Practx](docs/azure-devops-pipelines.md).
+
 ## Table of Contents
 
+- [Deployment paths](#deployment-paths)
 - [Quick Start](#quick-start)
 - [Azure Dev Center catalog](#azure-dev-center-catalog)
 - [Structure](#structure)
@@ -13,6 +20,8 @@ Hosted in Git, there is CICD integration with Azure Dev Center, if it works.
 - [Dev Center automation](#dev-center-automation)
 
 ## Quick Start
+
+> Want to deploy straight from GitHub without touching Azure Dev Center? Follow the streamlined instructions in [Using GitHub Without Azure Dev Center](docs/github-without-devcenter.md) and then return here when you are ready to adopt Dev Center again.
 
 ### Prerequisites
 

--- a/docs/azure-devops-pipelines.md
+++ b/docs/azure-devops-pipelines.md
@@ -1,0 +1,58 @@
+# Azure DevOps Pipelines for Practx
+
+The repository now supports Azure DevOps pipelines for both infrastructure provisioning and the Practx Static Web App deployment. This guide explains what each pipeline does and how to configure the required variables and service connections.
+
+## Infrastructure pipeline (`pipelines/practx-infra-azure-pipelines.yml`)
+
+This pipeline validates and deploys the Bicep templates under `infra/bicep/` using the Azure CLI. It runs a `what-if` preview before applying changes to help you understand the impact of the deployment.
+
+### Triggers
+- Branch: `main`
+- Paths: `infra/**` and the pipeline definition itself
+
+### Stages
+1. **Validate** – Executes `az deployment group what-if` against the target resource group.
+2. **Deploy** – Runs `az deployment group create` to apply the Bicep template when validation succeeds.
+
+### Required configuration
+Create a variable group named **`Practx-Infra`** (or define equivalent pipeline variables) with the following values:
+
+| Variable | Description |
+| --- | --- |
+| `AZURE_SERVICE_CONNECTION` | Name of an Azure Resource Manager service connection with permissions to the target subscription/resource group. |
+| `AZ_RESOURCE_GROUP` | Resource group that will host the Practx infrastructure. |
+| `AZ_LOCATION` | Azure region for the deployment (e.g., `westus2`). |
+| `NAME_PREFIX` | Prefix applied to deployed resource names (for example `practx`). |
+| `TENANT_ID` | Azure AD tenant ID used when creating Key Vault access policies. |
+| `FUNCTION_SKU` | *(Optional)* Azure Functions plan SKU. Defaults to `Y1` if omitted. |
+
+## Static Web App pipeline (`pipelines/practx-swa-azure-pipelines.yml`)
+
+This pipeline deploys the contents of `practx-swa/` to Azure Static Web Apps using the official Azure DevOps task. It installs API dependencies and then uploads the frontend and Azure Functions API.
+
+### Triggers
+- Branch: `main`
+- Paths: `practx-swa/**` and the pipeline definition itself
+
+### Stage
+- **BuildAndDeploy** – Installs Node.js, restores the API packages, and calls `AzureStaticWebApp@0` to publish the site.
+
+### Required configuration
+Create a variable group named **`Practx-SWA`** (or define the variables directly on the pipeline) with the following entries:
+
+| Variable | Description |
+| --- | --- |
+| `AZURE_STATIC_WEB_APPS_API_TOKEN` | Deployment token for the target Static Web App environment. |
+| `APP_LOCATION` | *(Optional)* Path to the frontend source relative to the repo root. Defaults to `practx-swa/frontend`. |
+| `API_LOCATION` | *(Optional)* Path to the Azure Functions API relative to the repo root. Defaults to `practx-swa/api`. |
+
+### Notes
+- The Static Web App task runs in “skip build” mode because the frontend is plain HTML/CSS/JS. Adjust the task inputs if you later introduce a build step.
+- The pipeline installs API dependencies with `npm install` so that runtime packages are validated before deployment.
+
+## Running the pipelines
+1. Import each YAML file into Azure DevOps as a new pipeline, pointing to the corresponding path in this repository.
+2. Link the appropriate variable group under **Pipeline settings → Variables**.
+3. Queue a manual run to test connectivity and confirm that the infrastructure deploys successfully and the Static Web App publishes without errors.
+
+These additions provide a fully supported alternative to the existing GitHub Actions workflow for teams that prefer Azure DevOps for CI/CD.

--- a/docs/github-without-devcenter.md
+++ b/docs/github-without-devcenter.md
@@ -1,0 +1,58 @@
+# Using GitHub Without Azure Dev Center
+
+Azure Dev Center remains checked into this repository so you can return to it later, but you do not need it to keep shipping from GitHub. This guide walks through a simple "GitHub only" path that provisions the practx infrastructure with the Azure CLI and relies on the existing GitHub Actions workflow to publish the Static Web App.
+
+## When to pick this path
+
+Choose the GitHub-only flow when:
+
+- You are the sole contributor (or have a very small team) and do not need the self-service environment management features from Dev Center yet.
+- You prefer to run infrastructure deployments on demand with the Azure CLI instead of through the Dev Center environment definitions.
+- You want to continue using GitHub Actions for the Static Web App without wiring Dev Center identities or catalog sync variables.
+
+You can leave the `Environments/` catalog intact. Nothing in the steps below depends on it, so you can revisit Dev Center later without rewriting the infrastructure templates.
+
+## Provision infrastructure directly with the Azure CLI
+
+1. Sign in and select the target subscription:
+
+   ```bash
+   az login
+   az account set --subscription <subscription-id>
+   ```
+
+2. Create (or reuse) a resource group for the practx environment:
+
+   ```bash
+   az group create --name <resource-group> --location <azure-region>
+   ```
+
+3. Deploy the Bicep template that normally runs through Dev Center. The `practix/infra/main.bicep` file emits the App Service plan/web app, API, Functions app, Key Vault, SQL flexible server, Storage account, Application Insights, and API Management resources for the chosen environment label.【F:practix/infra/main.bicep†L1-L87】 Prepare a parameters file (you can start from `practix/infra/main.parameters.json`) with the environment name, base name, admin credentials, Stripe keys, and B2C identifiers.【F:practix/infra/main.parameters.json†L1-L20】 Then run:
+
+   ```bash
+   az deployment group create \
+     --resource-group <resource-group> \
+     --template-file practix/infra/main.bicep \
+     --parameters @practix/infra/main.parameters.json
+   ```
+
+   Replace the parameter file path if you keep secrets in a secure location (for example, Azure Key Vault or an encrypted storage account). The deployment outputs include the web app, API app, Function app, SQL connection string, and Key Vault URI for follow-up configuration.【F:practix/infra/main.bicep†L73-L87】
+
+4. Keep the `.github/workflows/bicep-validate.yml` workflow enabled so pull requests still build any changed Bicep files. This guardrail catches template regressions even though you are not provisioning through Dev Center.【F:.github/workflows/bicep-validate.yml†L1-L57】
+
+## Deploy the Static Web App from GitHub
+
+The Static Web App does not rely on Dev Center. The workflow at `practx-swa/.github/workflows/azure-static-web-apps.yml` builds the frontend and API and uploads them when you push to `main` as long as the `AZURE_STATIC_WEB_APPS_API_TOKEN` secret is present.【F:practx-swa/.github/workflows/azure-static-web-apps.yml†L1-L33】
+
+1. In the Azure portal, open the Static Web App you created manually (or via the CLI bootstrap script in `practx-swa/README.md`). Generate a deployment token and store it as the `AZURE_STATIC_WEB_APPS_API_TOKEN` repository secret.
+2. Commit changes to `main` to publish. Pull requests continue to generate preview environments without additional configuration.【F:practx-swa/.github/workflows/azure-static-web-apps.yml†L18-L33】
+
+If you prefer to deploy the Static Web App from your local machine instead of GitHub Actions, run the bootstrap script documented in the SWA README to create/update the resource and then push local builds with `az staticwebapp upload`. The script already targets the `frontend` and `api` folders in this repository.【F:practx-swa/README.md†L42-L84】
+
+## What about Dev Center assets?
+
+- Leave the `devcenter-catalog-sync` workflow disabled (or remove its secrets) while you operate in GitHub-only mode. Nothing else in the repo requires those credentials.【F:.github/workflows/devcenter-catalog-sync.yml†L1-L49】
+- You can resume Dev Center later by re-enabling the secrets and syncing the catalog. The infrastructure templates and environment definitions remain valid, so no migration work is required.
+- Azure DevOps pipelines remain available if you decide to manage deployments there instead of GitHub; they do not conflict with the GitHub-only flow.【F:pipelines/practx-infra-azure-pipelines.yml†L1-L80】【F:pipelines/practx-swa-azure-pipelines.yml†L1-L46】
+
+With these steps you can keep the repository on GitHub, deploy infrastructure with a straightforward CLI invocation, and continue publishing the Static Web App without involving Azure Dev Center.

--- a/pipelines/practx-infra-azure-pipelines.yml
+++ b/pipelines/practx-infra-azure-pipelines.yml
@@ -1,0 +1,80 @@
+# Azure DevOps pipeline for provisioning Practx infrastructure with Bicep
+# Configure the following variable group or pipeline variables before running:
+#   AZURE_SERVICE_CONNECTION - name of service connection with contributor rights
+#   AZ_RESOURCE_GROUP - target resource group for the deployment
+#   AZ_LOCATION - Azure region for resources (e.g., westus2)
+#   NAME_PREFIX - prefix used for resource names (e.g., practx)
+#   TENANT_ID - Azure AD tenant id used for Key Vault access policies
+#   FUNCTION_SKU - optional Functions plan SKU (default Y1)
+# Optionally link a variable group named `Practx-Infra` that defines the variables above.
+
+trigger:
+  branches:
+    include:
+      - main
+  paths:
+    include:
+      - infra/*
+      - pipelines/practx-infra-azure-pipelines.yml
+
+variables:
+  - group: Practx-Infra
+  - name: FUNCTION_SKU
+    value: 'Y1'
+
+stages:
+  - stage: Validate
+    displayName: Validate Bicep deployment
+    jobs:
+      - job: WhatIf
+        displayName: Run what-if validation
+        pool:
+          vmImage: 'ubuntu-latest'
+        steps:
+          - checkout: self
+          - task: AzureCLI@2
+            displayName: Azure CLI what-if
+            inputs:
+              azureSubscription: $(AZURE_SERVICE_CONNECTION)
+              scriptType: bash
+              scriptLocation: inlineScript
+              inlineScript: |
+                set -euo pipefail
+                az deployment group what-if \
+                  --resource-group "$(AZ_RESOURCE_GROUP)" \
+                  --template-file infra/bicep/main.bicep \
+                  --parameters \
+                    namePrefix="$(NAME_PREFIX)" \
+                    tenantId="$(TENANT_ID)" \
+                    location="$(AZ_LOCATION)" \
+                    functionSku="$(FUNCTION_SKU)"
+
+  - stage: Deploy
+    displayName: Deploy infrastructure
+    dependsOn: Validate
+    condition: succeeded()
+    jobs:
+      - deployment: DeployBicep
+        displayName: Deploy Bicep template
+        environment: practx-infrastructure
+        strategy:
+          runOnce:
+            deploy:
+              steps:
+                - checkout: self
+                - task: AzureCLI@2
+                  displayName: Deploy resources
+                  inputs:
+                    azureSubscription: $(AZURE_SERVICE_CONNECTION)
+                    scriptType: bash
+                    scriptLocation: inlineScript
+                    inlineScript: |
+                      set -euo pipefail
+                      az deployment group create \
+                        --resource-group "$(AZ_RESOURCE_GROUP)" \
+                        --template-file infra/bicep/main.bicep \
+                        --parameters \
+                          namePrefix="$(NAME_PREFIX)" \
+                          tenantId="$(TENANT_ID)" \
+                          location="$(AZ_LOCATION)" \
+                          functionSku="$(FUNCTION_SKU)"

--- a/pipelines/practx-swa-azure-pipelines.yml
+++ b/pipelines/practx-swa-azure-pipelines.yml
@@ -1,0 +1,46 @@
+# Azure DevOps pipeline to build and deploy the Practx Static Web App
+# Required variables (variable group `Practx-SWA` recommended):
+#   AZURE_STATIC_WEB_APPS_API_TOKEN - deployment token from the Static Web App
+#   APP_LOCATION - optional override for frontend path (defaults to practx-swa/frontend)
+#   API_LOCATION - optional override for API path (defaults to practx-swa/api)
+
+trigger:
+  branches:
+    include:
+      - main
+  paths:
+    include:
+      - practx-swa/*
+      - pipelines/practx-swa-azure-pipelines.yml
+
+variables:
+  - group: Practx-SWA
+  - name: APP_LOCATION
+    value: 'practx-swa/frontend'
+  - name: API_LOCATION
+    value: 'practx-swa/api'
+
+stages:
+  - stage: BuildAndDeploy
+    displayName: Build and deploy Static Web App
+    jobs:
+      - job: DeploySWA
+        displayName: Deploy Practx Static Web App
+        pool:
+          vmImage: 'ubuntu-latest'
+        steps:
+          - checkout: self
+            clean: true
+          - task: NodeTool@0
+            displayName: Use Node.js 18.x
+            inputs:
+              versionSpec: '18.x'
+          - script: npm install --prefix $(API_LOCATION)
+            displayName: Install API dependencies
+          - task: AzureStaticWebApp@0
+            displayName: Deploy to Azure Static Web Apps
+            inputs:
+              app_location: $(APP_LOCATION)
+              api_location: $(API_LOCATION)
+              skip_app_build: true
+              azure_static_web_apps_api_token: $(AZURE_STATIC_WEB_APPS_API_TOKEN)

--- a/practx-swa/README.md
+++ b/practx-swa/README.md
@@ -59,6 +59,10 @@ Production-ready starter for the Practx marketing site running on Azure Static W
 
 A workflow at `.github/workflows/azure-static-web-apps.yml` deploys the app whenever changes are pushed to the `main` branch. The workflow expects a repository secret named `AZURE_STATIC_WEB_APPS_API_TOKEN` generated from the Azure portal for the Static Web App.
 
+### Azure DevOps Pipelines
+
+An alternative Azure DevOps pipeline definition is available at `pipelines/practx-swa-azure-pipelines.yml`. Import it into Azure DevOps and link a variable group containing `AZURE_STATIC_WEB_APPS_API_TOKEN` (the deployment token) along with any optional `APP_LOCATION` or `API_LOCATION` overrides. See [Azure DevOps Pipelines for Practx](../docs/azure-devops-pipelines.md) for detailed setup steps.
+
 ### Azure CLI Bootstrap Script
 
 Use the following script to create the resource group and Static Web App (fill in variables first):


### PR DESCRIPTION
## Summary
- add Azure DevOps YAML pipeline to validate and deploy the Bicep infrastructure templates
- add Azure DevOps YAML pipeline to deploy the Practx static web app from Azure DevOps
- document configuration steps for the new pipelines and link them from the static web app README

## Testing
- not run (pipeline definitions only)


------
https://chatgpt.com/codex/tasks/task_e_68e25c47977483238b8bd82c61d5786b