### PR TITLE
Constrain Bicep deployments to West US 2

### DIFF
--- a/docs/azure-devops-pipelines.md
+++ b/docs/azure-devops-pipelines.md
@@ -21,7 +21,7 @@ Create a variable group named **`Practx-Infra`** (or define equivalent pipeline 
 | --- | --- |
 | `AZURE_SERVICE_CONNECTION` | Name of an Azure Resource Manager service connection with permissions to the target subscription/resource group. |
 | `AZ_RESOURCE_GROUP` | Resource group that will host the Practx infrastructure. |
-| `AZ_LOCATION` | Azure region for the deployment (e.g., `westus2`). |
+| `AZ_LOCATION` | Azure region for the deployment (set to `westus2` for all Practx environments). |
 | `NAME_PREFIX` | Prefix applied to deployed resource names (for example `practx`). |
 | `TENANT_ID` | Azure AD tenant ID used when creating Key Vault access policies. |
 | `FUNCTION_SKU` | *(Optional)* Azure Functions plan SKU. Defaults to `Y1` if omitted. |

--- a/docs/github-without-devcenter.md
+++ b/docs/github-without-devcenter.md
@@ -21,13 +21,13 @@ You can leave the `Environments/` catalog intact. Nothing in the steps below dep
    az account set --subscription <subscription-id>
    ```
 
-2. Create (or reuse) a resource group for the practx environment:
+2. Create (or reuse) a resource group for the practx environment in **West US 2** (the required deployment region):
 
    ```bash
-   az group create --name <resource-group> --location <azure-region>
+   az group create --name <resource-group> --location westus2
    ```
 
-3. Deploy the Bicep template that normally runs through Dev Center. The `practix/infra/main.bicep` file emits the App Service plan/web app, API, Functions app, Key Vault, SQL flexible server, Storage account, Application Insights, and API Management resources for the chosen environment label.【F:practix/infra/main.bicep†L1-L87】 Prepare a parameters file (you can start from `practix/infra/main.parameters.json`) with the environment name, base name, admin credentials, Stripe keys, and B2C identifiers.【F:practix/infra/main.parameters.json†L1-L20】 Then run:
+3. Deploy the Bicep template that normally runs through Dev Center. The `practix/infra/main.bicep` file emits the App Service plan/web app, API, Functions app, Key Vault, SQL flexible server, Storage account, Application Insights, and API Management resources for the chosen environment label.【F:practix/infra/main.bicep†L1-L87】 Prepare a parameters file (you can start from `practix/infra/main.parameters.json`) with the environment name, base name, admin credentials, Stripe keys, and B2C identifiers—keep the `location` parameter set to `westus2` to match the required region.【F:practix/infra/main.parameters.json†L1-L20】 Then run:
 
    ```bash
    az deployment group create \

--- a/infra/bicep/main.bicep
+++ b/infra/bicep/main.bicep
@@ -1,5 +1,8 @@
 param namePrefix string
-param location string = resourceGroup().location
+@allowed([
+  'westus2'
+])
+param location string = 'westus2'
 param tags object = {}
 param functionSku string = 'Y1'
 param tenantId string

--- a/pipelines/practx-infra-azure-pipelines.yml
+++ b/pipelines/practx-infra-azure-pipelines.yml
@@ -2,7 +2,7 @@
 # Configure the following variable group or pipeline variables before running:
 #   AZURE_SERVICE_CONNECTION - name of service connection with contributor rights
 #   AZ_RESOURCE_GROUP - target resource group for the deployment
-#   AZ_LOCATION - Azure region for resources (e.g., westus2)
+#   AZ_LOCATION - Azure region for resources (must be westus2)
 #   NAME_PREFIX - prefix used for resource names (e.g., practx)
 #   TENANT_ID - Azure AD tenant id used for Key Vault access policies
 #   FUNCTION_SKU - optional Functions plan SKU (default Y1)
@@ -19,6 +19,8 @@ trigger:
 
 variables:
   - group: Practx-Infra
+  - name: AZ_LOCATION
+    value: 'westus2'
   - name: FUNCTION_SKU
     value: 'Y1'
 

--- a/practix/infra/main.bicep
+++ b/practix/infra/main.bicep
@@ -1,6 +1,9 @@
 param env string
 param baseName string
-param location string = resourceGroup().location
+@allowed([
+  'westus2'
+])
+param location string = 'westus2'
 
 @secure()
 param sqlAdminLogin string

--- a/practix/infra/main.parameters.json
+++ b/practix/infra/main.parameters.json
@@ -4,7 +4,7 @@
   "parameters": {
     "env": { "value": "dev" },
     "baseName": { "value": "practix" },
-    "location": { "value": "eastus" },
+    "location": { "value": "westus2" },
     "sqlAdminLogin": { "value": "practixadmin" },
     "sqlAdminPassword": { "value": "ChangeMe123!" },
     "stripeSecretKey": { "value": "sk_test_placeholder" },


### PR DESCRIPTION
## Summary
- restrict both infrastructure Bicep entry points so deployments only target the required West US 2 region

## Testing
- not run (template update only)

------
https://chatgpt.com/codex/tasks/task_e_68e27c039c988323903de8f0895ce3f5