### PR TITLE
Add Azure Static Web Apps workflow to root

### DIFF
--- a/.github/workflows/azure-static-web-apps-mango-hill-0cb59961e.yml
+++ b/.github/workflows/azure-static-web-apps-mango-hill-0cb59961e.yml
@@ -28,8 +28,8 @@ jobs:
           action: "upload"
           ###### Repository/Build Configurations - These values can be configured to match your app requirements. ######
           # For more information regarding Static Web App workflow configurations, please visit: https://aka.ms/swaworkflowconfig
-          app_location: "frontend" # App source code path
-          api_location: "api" # Api source code path - optional
+          app_location: "practx-swa/frontend" # App source code path
+          api_location: "practx-swa/api" # Api source code path - optional
           output_location: "" # Built app content directory - optional
           ###### End of Repository/Build Configurations ######
 

--- a/.github/workflows/azure-static-web-apps.yml
+++ b/.github/workflows/azure-static-web-apps.yml
@@ -1,0 +1,38 @@
+name: Deploy to Azure Static Web Apps
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+    types: [opened, synchronize, reopened, closed]
+    branches:
+      - main
+
+jobs:
+  build_and_deploy:
+    if: ${{ github.event_name == 'push' || github.event.action != 'closed' }}
+    runs-on: ubuntu-latest
+    name: Build and Deploy Job
+    steps:
+      - uses: actions/checkout@v3
+      - name: Build and Deploy
+        uses: Azure/static-web-apps-deploy@v1
+        with:
+          azure_static_web_apps_api_token: ${{ secrets.AZURE_STATIC_WEB_APPS_API_TOKEN }}
+          repo_token: ${{ secrets.GITHUB_TOKEN }}
+          action: "upload"
+          app_location: "frontend"
+          api_location: "api"
+          output_location: ""
+
+  close_pull_request:
+    if: ${{ github.event_name == 'pull_request' && github.event.action == 'closed' }}
+    runs-on: ubuntu-latest
+    name: Close Pull Request Job
+    steps:
+      - name: Close Pull Request
+        uses: Azure/static-web-apps-deploy@v1
+        with:
+          azure_static_web_apps_api_token: ${{ secrets.AZURE_STATIC_WEB_APPS_API_TOKEN }}
+          action: "close"

--- a/.github/workflows/azure-static-web-apps.yml
+++ b/.github/workflows/azure-static-web-apps.yml
@@ -22,8 +22,8 @@ jobs:
           azure_static_web_apps_api_token: ${{ secrets.AZURE_STATIC_WEB_APPS_API_TOKEN }}
           repo_token: ${{ secrets.GITHUB_TOKEN }}
           action: "upload"
-          app_location: "frontend"
-          api_location: "api"
+          app_location: "practx-swa/frontend"
+          api_location: "practx-swa/api"
           output_location: ""
 
   close_pull_request:


### PR DESCRIPTION
## Summary
- copy the Azure Static Web Apps deployment workflow into the repository's root .github/workflows directory so GitHub Actions can run it

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e2f9d419a4832381a7a4983182b0c8