### PR TITLE
Trigger Static Web App pipeline on non-main branches

### DIFF
--- a/.github/workflows/azure-static-web-apps-mango-hill-0cb59961e.yml
+++ b/.github/workflows/azure-static-web-apps-mango-hill-0cb59961e.yml
@@ -2,16 +2,11 @@ name: Azure Static Web Apps CI/CD
 
 on:
   push:
-    branches:
-      - main
-  pull_request:
-    types: [opened, synchronize, reopened, closed]
-    branches:
+    branches-ignore:
       - main
 
 jobs:
   build_and_deploy_job:
-    if: github.event_name == 'push' || (github.event_name == 'pull_request' && github.event.action != 'closed')
     runs-on: ubuntu-latest
     name: Build and Deploy Job
     steps:
@@ -32,15 +27,3 @@ jobs:
           api_location: "practx-swa/api" # Api source code path - optional
           output_location: "" # Built app content directory - optional
           ###### End of Repository/Build Configurations ######
-
-  close_pull_request_job:
-    if: github.event_name == 'pull_request' && github.event.action == 'closed'
-    runs-on: ubuntu-latest
-    name: Close Pull Request Job
-    steps:
-      - name: Close Pull Request
-        id: closepullrequest
-        uses: Azure/static-web-apps-deploy@v1
-        with:
-          azure_static_web_apps_api_token: ${{ secrets.AZURE_STATIC_WEB_APPS_API_TOKEN_MANGO_HILL_0CB59961E }}
-          action: "close"


### PR DESCRIPTION
## Summary
- update the Azure Static Web Apps workflow to ignore pushes to main so dev deploys occur from other branches

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e3c29d46348323a93fa8296daa33b9