### PR TITLE
Align Static Web App workflow configuration

### DIFF
--- a/.github/workflows/azure-static-web-apps.yml
+++ b/.github/workflows/azure-static-web-apps.yml
@@ -1,12 +1,18 @@
 name: Azure Static Web Apps CI/CD
 
 on:
+  workflow_dispatch:
   push:
-    branches-ignore:
+    branches:
+      - main
+  pull_request:
+    types: [opened, synchronize, reopened, closed]
+    branches:
       - main
 
 jobs:
   build_and_deploy_job:
+    if: ${{ github.event_name == 'push' || github.event.action != 'closed' }}
     runs-on: ubuntu-latest
     name: Build and Deploy Job
     steps:
@@ -19,7 +25,7 @@ jobs:
         uses: Azure/static-web-apps-deploy@v1
         with:
           azure_static_web_apps_api_token: ${{ secrets.AZURE_STATIC_WEB_APPS_API_TOKEN_MANGO_HILL_0CB59961E }}
-          repo_token: ${{ secrets.GITHUB_TOKEN }} # Used for Github integrations (i.e. PR comments)
+          repo_token: ${{ secrets.GITHUB_TOKEN }} # Used for GitHub integrations (i.e. PR comments)
           action: "upload"
           ###### Repository/Build Configurations - These values can be configured to match your app requirements. ######
           # For more information regarding Static Web App workflow configurations, please visit: https://aka.ms/swaworkflowconfig
@@ -27,3 +33,14 @@ jobs:
           api_location: "practx-swa/api" # Api source code path - optional
           output_location: "" # Built app content directory - optional
           ###### End of Repository/Build Configurations ######
+
+  close_pull_request_job:
+    if: ${{ github.event_name == 'pull_request' && github.event.action == 'closed' }}
+    runs-on: ubuntu-latest
+    name: Close Pull Request Job
+    steps:
+      - name: Close Pull Request
+        uses: Azure/static-web-apps-deploy@v1
+        with:
+          azure_static_web_apps_api_token: ${{ secrets.AZURE_STATIC_WEB_APPS_API_TOKEN_MANGO_HILL_0CB59961E }}
+          action: "close"

--- a/docs/github-without-devcenter.md
+++ b/docs/github-without-devcenter.md
@@ -42,10 +42,10 @@ You can leave the `Environments/` catalog intact. Nothing in the steps below dep
 
 ## Deploy the Static Web App from GitHub
 
-The Static Web App does not rely on Dev Center. The workflow at `practx-swa/.github/workflows/azure-static-web-apps.yml` builds the frontend and API and uploads them when you push to `main` as long as the `AZURE_STATIC_WEB_APPS_API_TOKEN` secret is present.【F:practx-swa/.github/workflows/azure-static-web-apps.yml†L1-L33】
+The Static Web App does not rely on Dev Center. The workflow at `.github/workflows/azure-static-web-apps.yml` builds the frontend and API and uploads them when you push to `main` as long as the `AZURE_STATIC_WEB_APPS_API_TOKEN_MANGO_HILL_0CB59961E` secret is present.【F:.github/workflows/azure-static-web-apps.yml†L1-L40】
 
-1. In the Azure portal, open the Static Web App you created manually (or via the CLI bootstrap script in `practx-swa/README.md`). Generate a deployment token and store it as the `AZURE_STATIC_WEB_APPS_API_TOKEN` repository secret.
-2. Commit changes to `main` to publish. Pull requests continue to generate preview environments without additional configuration.【F:practx-swa/.github/workflows/azure-static-web-apps.yml†L18-L33】
+1. In the Azure portal, open the Static Web App you created manually (or via the CLI bootstrap script in `practx-swa/README.md`). Generate a deployment token and store it as the `AZURE_STATIC_WEB_APPS_API_TOKEN_MANGO_HILL_0CB59961E` repository secret.
+2. Commit changes to `main` to publish. Pull requests continue to generate preview environments without additional configuration.【F:.github/workflows/azure-static-web-apps.yml†L9-L40】
 
 If you prefer to deploy the Static Web App from your local machine instead of GitHub Actions, run the bootstrap script documented in the SWA README to create/update the resource and then push local builds with `az staticwebapp upload`. The script already targets the `frontend` and `api` folders in this repository.【F:practx-swa/README.md†L42-L84】
 

--- a/practx-swa/README.md
+++ b/practx-swa/README.md
@@ -57,7 +57,7 @@ Production-ready starter for the Practx marketing site running on Azure Static W
 
 ### GitHub Actions
 
-A workflow at `.github/workflows/azure-static-web-apps.yml` deploys the app whenever changes are pushed to the `main` branch. The workflow expects a repository secret named `AZURE_STATIC_WEB_APPS_API_TOKEN` generated from the Azure portal for the Static Web App.
+A workflow at `../.github/workflows/azure-static-web-apps.yml` deploys the app whenever changes are pushed to the `main` branch. The workflow expects a repository secret named `AZURE_STATIC_WEB_APPS_API_TOKEN_MANGO_HILL_0CB59961E` generated from the Azure portal for the Static Web App.
 
 ### Azure DevOps Pipelines
 
@@ -125,9 +125,6 @@ practx-swa/
     package.json
     host.json
     .funcignore
-  .github/
-    workflows/
-      azure-static-web-apps.yml
   README.md
   LICENSE
 ```


### PR DESCRIPTION
## Summary
- rename the Azure Static Web Apps workflow back to azure-static-web-apps.yml so GitHub picks it up
- re-enable main branch, pull request, and manual triggers plus the close job to clean up preview environments
- update documentation to point at the new workflow filename and secret name

## Testing
- not run (workflow/configuration only)


------
https://chatgpt.com/codex/tasks/task_e_68e3db15ce0c832398cb9a6a4910add4