### PR TITLE
Restore franchise copy outside of navigation updates

### DIFF
--- a/practx-swa/frontend/admin.html
+++ b/practx-swa/frontend/admin.html
@@ -17,17 +17,16 @@
 <body>
   <header>
     <nav>
-      <a class="logo" href="/">
+      <a class="logo" href="/index.html">
         <img src="assets/logo.svg" alt="Practx logo" width="32" height="32" />
         <span>Practx</span>
       </a>
       <ul>
-        <li><a href="/">Home</a></li>
         <li><a href="/practice-management.html">Practice Management</a></li>
         <li><a href="/equipment-management.html">Equipment Management</a></li>
         <li><a href="/patient-outreach.html">Patient Outreach</a></li>
-        <li><a href="/smile-spa-franchise.html">Smile Spa Franchise</a></li>
-        <li><a href="/practx-service-franchise.html">Practx Service Franchise</a></li>
+        <li><a href="/smile-spa-franchise.html">Expand Access</a></li>
+        <li><a href="/practx-service-franchise.html">Ensure Uptime</a></li>
       </ul>
     </nav>
   </header>

--- a/practx-swa/frontend/equipment-management.html
+++ b/practx-swa/frontend/equipment-management.html
@@ -17,17 +17,16 @@
 <body>
   <header>
     <nav>
-      <a class="logo" href="/">
+      <a class="logo" href="/index.html">
         <img src="assets/logo.svg" alt="Practx logo" width="32" height="32" />
         <span>Practx</span>
       </a>
       <ul>
-        <li><a href="/">Home</a></li>
         <li><a href="/practice-management.html">Practice Management</a></li>
         <li><a class="active" href="/equipment-management.html">Equipment Management</a></li>
         <li><a href="/patient-outreach.html">Patient Outreach</a></li>
-        <li><a href="/smile-spa-franchise.html">Smile Spa Franchise</a></li>
-        <li><a href="/practx-service-franchise.html">Practx Service Franchise</a></li>
+        <li><a href="/smile-spa-franchise.html">Expand Access</a></li>
+        <li><a href="/practx-service-franchise.html">Ensure Uptime</a></li>
       </ul>
     </nav>
   </header>

--- a/practx-swa/frontend/franchise.html
+++ b/practx-swa/frontend/franchise.html
@@ -18,17 +18,16 @@
 <body>
   <header>
     <nav>
-      <a class="logo" href="/">
+      <a class="logo" href="/index.html">
         <img src="assets/logo.svg" alt="Practx logo" width="32" height="32" />
         <span>Practx</span>
       </a>
       <ul>
-        <li><a href="/">Home</a></li>
         <li><a href="/practice-management.html">Practice Management</a></li>
         <li><a href="/equipment-management.html">Equipment Management</a></li>
         <li><a href="/patient-outreach.html">Patient Outreach</a></li>
-        <li><a href="/smile-spa-franchise.html">Smile Spa Franchise</a></li>
-        <li><a href="/practx-service-franchise.html">Practx Service Franchise</a></li>
+        <li><a href="/smile-spa-franchise.html">Expand Access</a></li>
+        <li><a href="/practx-service-franchise.html">Ensure Uptime</a></li>
       </ul>
     </nav>
   </header>

--- a/practx-swa/frontend/hygiene.html
+++ b/practx-swa/frontend/hygiene.html
@@ -18,17 +18,16 @@
 <body>
   <header>
     <nav>
-      <a class="logo" href="/">
+      <a class="logo" href="/index.html">
         <img src="assets/logo.svg" alt="Practx logo" width="32" height="32" />
         <span>Practx</span>
       </a>
       <ul>
-        <li><a href="/">Home</a></li>
         <li><a href="/practice-management.html">Practice Management</a></li>
         <li><a href="/equipment-management.html">Equipment Management</a></li>
         <li><a href="/patient-outreach.html">Patient Outreach</a></li>
-        <li><a href="/smile-spa-franchise.html">Smile Spa Franchise</a></li>
-        <li><a href="/practx-service-franchise.html">Practx Service Franchise</a></li>
+        <li><a href="/smile-spa-franchise.html">Expand Access</a></li>
+        <li><a href="/practx-service-franchise.html">Ensure Uptime</a></li>
       </ul>
     </nav>
   </header>

--- a/practx-swa/frontend/index.html
+++ b/practx-swa/frontend/index.html
@@ -18,17 +18,16 @@
 <body>
   <header>
     <nav>
-      <a class="logo" href="/">
+      <a class="logo" href="/index.html">
         <img src="assets/logo.svg" alt="Practx logo" width="32" height="32" />
         <span>Practx</span>
       </a>
       <ul>
-        <li><a class="active" href="/">Home</a></li>
         <li><a href="/practice-management.html">Practice Management</a></li>
         <li><a href="/equipment-management.html">Equipment Management</a></li>
         <li><a href="/patient-outreach.html">Patient Outreach</a></li>
-        <li><a href="/smile-spa-franchise.html">Smile Spa Franchise</a></li>
-        <li><a href="/practx-service-franchise.html">Practx Service Franchise</a></li>
+        <li><a href="/smile-spa-franchise.html">Expand Access</a></li>
+        <li><a href="/practx-service-franchise.html">Ensure Uptime</a></li>
       </ul>
     </nav>
   </header>

--- a/practx-swa/frontend/marketing.html
+++ b/practx-swa/frontend/marketing.html
@@ -17,17 +17,16 @@
 <body>
   <header>
     <nav>
-      <a class="logo" href="/">
+      <a class="logo" href="/index.html">
         <img src="assets/logo.svg" alt="Practx logo" width="32" height="32" />
         <span>Practx</span>
       </a>
       <ul>
-        <li><a href="/">Home</a></li>
         <li><a href="/practice-management.html">Practice Management</a></li>
         <li><a href="/equipment-management.html">Equipment Management</a></li>
         <li><a href="/patient-outreach.html">Patient Outreach</a></li>
-        <li><a href="/smile-spa-franchise.html">Smile Spa Franchise</a></li>
-        <li><a href="/practx-service-franchise.html">Practx Service Franchise</a></li>
+        <li><a href="/smile-spa-franchise.html">Expand Access</a></li>
+        <li><a href="/practx-service-franchise.html">Ensure Uptime</a></li>
       </ul>
     </nav>
   </header>

--- a/practx-swa/frontend/patient-outreach.html
+++ b/practx-swa/frontend/patient-outreach.html
@@ -17,17 +17,16 @@
 <body>
   <header>
     <nav>
-      <a class="logo" href="/">
+      <a class="logo" href="/index.html">
         <img src="assets/logo.svg" alt="Practx logo" width="32" height="32" />
         <span>Practx</span>
       </a>
       <ul>
-        <li><a href="/">Home</a></li>
         <li><a href="/practice-management.html">Practice Management</a></li>
         <li><a href="/equipment-management.html">Equipment Management</a></li>
         <li><a class="active" href="/patient-outreach.html">Patient Outreach</a></li>
-        <li><a href="/smile-spa-franchise.html">Smile Spa Franchise</a></li>
-        <li><a href="/practx-service-franchise.html">Practx Service Franchise</a></li>
+        <li><a href="/smile-spa-franchise.html">Expand Access</a></li>
+        <li><a href="/practx-service-franchise.html">Ensure Uptime</a></li>
       </ul>
     </nav>
   </header>

--- a/practx-swa/frontend/practice-management.html
+++ b/practx-swa/frontend/practice-management.html
@@ -17,17 +17,16 @@
 <body>
   <header>
     <nav>
-      <a class="logo" href="/">
+      <a class="logo" href="/index.html">
         <img src="assets/logo.svg" alt="Practx logo" width="32" height="32" />
         <span>Practx</span>
       </a>
       <ul>
-        <li><a href="/">Home</a></li>
         <li><a class="active" href="/practice-management.html">Practice Management</a></li>
         <li><a href="/equipment-management.html">Equipment Management</a></li>
         <li><a href="/patient-outreach.html">Patient Outreach</a></li>
-        <li><a href="/smile-spa-franchise.html">Smile Spa Franchise</a></li>
-        <li><a href="/practx-service-franchise.html">Practx Service Franchise</a></li>
+        <li><a href="/smile-spa-franchise.html">Expand Access</a></li>
+        <li><a href="/practx-service-franchise.html">Ensure Uptime</a></li>
       </ul>
     </nav>
   </header>

--- a/practx-swa/frontend/practx-service-franchise.html
+++ b/practx-swa/frontend/practx-service-franchise.html
@@ -17,17 +17,16 @@
 <body>
   <header>
     <nav>
-      <a class="logo" href="/">
+      <a class="logo" href="/index.html">
         <img src="assets/logo.svg" alt="Practx logo" width="32" height="32" />
         <span>Practx</span>
       </a>
       <ul>
-        <li><a href="/">Home</a></li>
         <li><a href="/practice-management.html">Practice Management</a></li>
         <li><a href="/equipment-management.html">Equipment Management</a></li>
         <li><a href="/patient-outreach.html">Patient Outreach</a></li>
-        <li><a href="/smile-spa-franchise.html">Smile Spa Franchise</a></li>
-        <li><a class="active" href="/practx-service-franchise.html">Practx Service Franchise</a></li>
+        <li><a href="/smile-spa-franchise.html">Expand Access</a></li>
+        <li><a class="active" href="/practx-service-franchise.html">Ensure Uptime</a></li>
       </ul>
     </nav>
   </header>

--- a/practx-swa/frontend/procurement.html
+++ b/practx-swa/frontend/procurement.html
@@ -17,17 +17,16 @@
 <body>
   <header>
     <nav>
-      <a class="logo" href="/">
+      <a class="logo" href="/index.html">
         <img src="assets/logo.svg" alt="Practx logo" width="32" height="32" />
         <span>Practx</span>
       </a>
       <ul>
-        <li><a href="/">Home</a></li>
         <li><a href="/practice-management.html">Practice Management</a></li>
         <li><a href="/equipment-management.html">Equipment Management</a></li>
         <li><a href="/patient-outreach.html">Patient Outreach</a></li>
-        <li><a href="/smile-spa-franchise.html">Smile Spa Franchise</a></li>
-        <li><a href="/practx-service-franchise.html">Practx Service Franchise</a></li>
+        <li><a href="/smile-spa-franchise.html">Expand Access</a></li>
+        <li><a href="/practx-service-franchise.html">Ensure Uptime</a></li>
       </ul>
     </nav>
   </header>

--- a/practx-swa/frontend/smile-spa-franchise.html
+++ b/practx-swa/frontend/smile-spa-franchise.html
@@ -17,17 +17,16 @@
 <body>
   <header>
     <nav>
-      <a class="logo" href="/">
+      <a class="logo" href="/index.html">
         <img src="assets/logo.svg" alt="Practx logo" width="32" height="32" />
         <span>Practx</span>
       </a>
       <ul>
-        <li><a href="/">Home</a></li>
         <li><a href="/practice-management.html">Practice Management</a></li>
         <li><a href="/equipment-management.html">Equipment Management</a></li>
         <li><a href="/patient-outreach.html">Patient Outreach</a></li>
-        <li><a class="active" href="/smile-spa-franchise.html">Smile Spa Franchise</a></li>
-        <li><a href="/practx-service-franchise.html">Practx Service Franchise</a></li>
+        <li><a class="active" href="/smile-spa-franchise.html">Expand Access</a></li>
+        <li><a href="/practx-service-franchise.html">Ensure Uptime</a></li>
       </ul>
     </nav>
   </header>

--- a/practx-swa/frontend/staffing.html
+++ b/practx-swa/frontend/staffing.html
@@ -17,17 +17,16 @@
 <body>
   <header>
     <nav>
-      <a class="logo" href="/">
+      <a class="logo" href="/index.html">
         <img src="assets/logo.svg" alt="Practx logo" width="32" height="32" />
         <span>Practx</span>
       </a>
       <ul>
-        <li><a href="/">Home</a></li>
         <li><a href="/practice-management.html">Practice Management</a></li>
         <li><a href="/equipment-management.html">Equipment Management</a></li>
         <li><a href="/patient-outreach.html">Patient Outreach</a></li>
-        <li><a href="/smile-spa-franchise.html">Smile Spa Franchise</a></li>
-        <li><a href="/practx-service-franchise.html">Practx Service Franchise</a></li>
+        <li><a href="/smile-spa-franchise.html">Expand Access</a></li>
+        <li><a href="/practx-service-franchise.html">Ensure Uptime</a></li>
       </ul>
     </nav>
   </header>

--- a/practx-swa/frontend/thank-you.html
+++ b/practx-swa/frontend/thank-you.html
@@ -17,17 +17,16 @@
 <body>
   <header>
     <nav>
-      <a class="logo" href="/">
+      <a class="logo" href="/index.html">
         <img src="assets/logo.svg" alt="Practx logo" width="32" height="32" />
         <span>Practx</span>
       </a>
       <ul>
-        <li><a href="/">Home</a></li>
         <li><a href="/practice-management.html">Practice Management</a></li>
         <li><a href="/equipment-management.html">Equipment Management</a></li>
         <li><a href="/patient-outreach.html">Patient Outreach</a></li>
-        <li><a href="/smile-spa-franchise.html">Smile Spa Franchise</a></li>
-        <li><a href="/practx-service-franchise.html">Practx Service Franchise</a></li>
+        <li><a href="/smile-spa-franchise.html">Expand Access</a></li>
+        <li><a href="/practx-service-franchise.html">Ensure Uptime</a></li>
       </ul>
     </nav>
   </header>


### PR DESCRIPTION
## Summary
- restore the original Smile Spa and Practx Service Franchise marketing language on the index and franchise landing pages
- return the franchise overview metadata to the previous Service & Smile Spa wording while keeping the navigation labels intact

## Testing
- not run (static content)

------
https://chatgpt.com/codex/tasks/task_e_68e508792b7883238e17f08198d95b84