### PR TITLE
Align waitlist CTAs with signup form

### DIFF
--- a/practx-swa/frontend/index.html
+++ b/practx-swa/frontend/index.html
@@ -38,7 +38,6 @@
       <p>Practx connects the modern dental practice with always-on software, predictive equipment support, human patient outreach, and two franchise paths built around the Practx identity.</p>
       <div class="hero-actions">
         <a class="button" href="#signup">Join the waitlist</a>
-        <a class="text-link" href="mailto:hello@practx.io?subject=Practx%20Partnership">Talk with our team →</a>
       </div>
     </section>
 
@@ -91,8 +90,7 @@
         </article>
       </div>
       <div class="cta-row">
-        <a class="button" href="mailto:hello@practx.io?subject=Practx%20Demo">Request a combined demo</a>
-        <a class="text-link" href="#signup">Join the waitlist →</a>
+        <a class="button" href="#signup">Request a combined demo</a>
       </div>
     </section>
 

--- a/practx-swa/frontend/practice-management.html
+++ b/practx-swa/frontend/practice-management.html
@@ -36,7 +36,7 @@
       <h1>Command your entire practice from Practx.</h1>
       <p>Scheduling, billing, charting, inventory, and analytics in one secure platform — paired with plug-and-play Clinic-in-a-Box hardware when you need it.</p>
       <div class="hero-actions">
-        <a class="button" href="mailto:hello@practx.io?subject=Practx%20Practice%20Management">Request a demo</a>
+        <a class="button" href="/index.html#signup">Request a demo</a>
         <a class="text-link" href="#platform">See what's included →</a>
       </div>
     </section>


### PR DESCRIPTION
## Summary
- remove the "Talk with our team" link from the homepage hero
- point demo and waitlist pill buttons to the signup form anchor
- remove the "Join the waitlist →" text link from the homepage combined CTA

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e57af857108323ba9e64d458f395c5