### PR TITLE
Switch SWA HTML assets to logo.png

### DIFF
--- a/practx-swa/README.md
+++ b/practx-swa/README.md
@@ -107,7 +107,7 @@ az staticwebapp create \
 practx-swa/
   frontend/
     assets/
-      logo.svg
+      logo.png
       styles.css
     index.html
     hygiene.html

--- a/practx-swa/frontend/about.html
+++ b/practx-swa/frontend/about.html
@@ -9,16 +9,16 @@
   <meta property="og:description" content="Discover how Practx is expanding access to dental care through connected practice, equipment, patient, and community solutions." />
   <meta property="og:type" content="website" />
   <meta property="og:url" content="https://practx.io/about.html" />
-  <meta property="og:image" content="https://practx.io/assets/logo.svg" />
+  <meta property="og:image" content="https://practx.io/assets/logo.png" />
   <meta name="twitter:card" content="summary" />
-  <link rel="icon" href="assets/logo.svg" type="image/svg+xml" />
+  <link rel="icon" href="assets/logo.png" type="image/png" />
   <link rel="stylesheet" href="assets/styles.css" />
 </head>
 <body>
   <header>
     <nav>
       <a class="logo" href="/index.html">
-        <img src="assets/logo.svg" alt="Practx logo" width="32" height="32" />
+        <img src="assets/logo.png" alt="Practx logo" width="32" height="32" />
         <span>Practx</span>
       </a>
       <ul>

--- a/practx-swa/frontend/admin.html
+++ b/practx-swa/frontend/admin.html
@@ -9,16 +9,16 @@
   <meta property="og:description" content="Automated billing, payroll, and HR for dental practices and DSOs — accuracy, compliance, and speed." />
   <meta property="og:type" content="website" />
   <meta property="og:url" content="https://practx.io/admin.html" />
-  <meta property="og:image" content="https://practx.io/assets/logo.svg" />
+  <meta property="og:image" content="https://practx.io/assets/logo.png" />
   <meta name="twitter:card" content="summary" />
-  <link rel="icon" href="assets/logo.svg" type="image/svg+xml" />
+  <link rel="icon" href="assets/logo.png" type="image/png" />
   <link rel="stylesheet" href="assets/styles.css" />
 </head>
 <body>
   <header>
     <nav>
       <a class="logo" href="/index.html">
-        <img src="assets/logo.svg" alt="Practx logo" width="32" height="32" />
+        <img src="assets/logo.png" alt="Practx logo" width="32" height="32" />
         <span>Practx</span>
       </a>
       <ul>

--- a/practx-swa/frontend/careers.html
+++ b/practx-swa/frontend/careers.html
@@ -9,16 +9,16 @@
   <meta property="og:description" content="Discover how Practx teammates design and deliver access-first dental experiences." />
   <meta property="og:type" content="website" />
   <meta property="og:url" content="https://practx.io/careers.html" />
-  <meta property="og:image" content="https://practx.io/assets/logo.svg" />
+  <meta property="og:image" content="https://practx.io/assets/logo.png" />
   <meta name="twitter:card" content="summary" />
-  <link rel="icon" href="assets/logo.svg" type="image/svg+xml" />
+  <link rel="icon" href="assets/logo.png" type="image/png" />
   <link rel="stylesheet" href="assets/styles.css" />
 </head>
 <body>
   <header>
     <nav>
       <a class="logo" href="/index.html">
-        <img src="assets/logo.svg" alt="Practx logo" width="32" height="32" />
+        <img src="assets/logo.png" alt="Practx logo" width="32" height="32" />
         <span>Practx</span>
       </a>
       <ul>

--- a/practx-swa/frontend/contact.html
+++ b/practx-swa/frontend/contact.html
@@ -9,16 +9,16 @@
   <meta property="og:description" content="We help practices, partners, and press connect with the right Practx team." />
   <meta property="og:type" content="website" />
   <meta property="og:url" content="https://practx.io/contact.html" />
-  <meta property="og:image" content="https://practx.io/assets/logo.svg" />
+  <meta property="og:image" content="https://practx.io/assets/logo.png" />
   <meta name="twitter:card" content="summary" />
-  <link rel="icon" href="assets/logo.svg" type="image/svg+xml" />
+  <link rel="icon" href="assets/logo.png" type="image/png" />
   <link rel="stylesheet" href="assets/styles.css" />
 </head>
 <body>
   <header>
     <nav>
       <a class="logo" href="/index.html">
-        <img src="assets/logo.svg" alt="Practx logo" width="32" height="32" />
+        <img src="assets/logo.png" alt="Practx logo" width="32" height="32" />
         <span>Practx</span>
       </a>
       <ul>

--- a/practx-swa/frontend/equipment-management.html
+++ b/practx-swa/frontend/equipment-management.html
@@ -9,16 +9,16 @@
   <meta property="og:description" content="Unify asset visibility, predictive maintenance, and coordinated service so clinicians stay focused on care." />
   <meta property="og:type" content="website" />
   <meta property="og:url" content="https://practx.io/equipment-management.html" />
-  <meta property="og:image" content="https://practx.io/assets/logo.svg" />
+  <meta property="og:image" content="https://practx.io/assets/logo.png" />
   <meta name="twitter:card" content="summary" />
-  <link rel="icon" href="assets/logo.svg" type="image/svg+xml" />
+  <link rel="icon" href="assets/logo.png" type="image/png" />
   <link rel="stylesheet" href="assets/styles.css" />
 </head>
 <body>
   <header>
     <nav>
       <a class="logo" href="/index.html">
-        <img src="assets/logo.svg" alt="Practx logo" width="32" height="32" />
+        <img src="assets/logo.png" alt="Practx logo" width="32" height="32" />
         <span>Practx</span>
       </a>
       <ul>

--- a/practx-swa/frontend/franchise.html
+++ b/practx-swa/frontend/franchise.html
@@ -9,9 +9,9 @@
   <meta property="og:description" content="Launch a white-glove dental service and smile spa franchise with Practx operations, brand playbooks, and membership tech." />
   <meta property="og:type" content="website" />
   <meta property="og:url" content="https://practx.io/franchise.html" />
-  <meta property="og:image" content="https://practx.io/assets/logo.svg" />
+  <meta property="og:image" content="https://practx.io/assets/logo.png" />
   <meta name="twitter:card" content="summary" />
-  <link rel="icon" href="assets/logo.svg" type="image/svg+xml" />
+  <link rel="icon" href="assets/logo.png" type="image/png" />
   <link rel="stylesheet" href="assets/styles.css" />
   <script defer src="signup.js"></script>
 </head>
@@ -19,7 +19,7 @@
   <header>
     <nav>
       <a class="logo" href="/index.html">
-        <img src="assets/logo.svg" alt="Practx logo" width="32" height="32" />
+        <img src="assets/logo.png" alt="Practx logo" width="32" height="32" />
         <span>Practx</span>
       </a>
       <ul>

--- a/practx-swa/frontend/hygiene.html
+++ b/practx-swa/frontend/hygiene.html
@@ -9,9 +9,9 @@
   <meta property="og:description" content="Deliver curated hygiene kits on autopilot with Practx hygiene subscriptions designed for modern dental teams." />
   <meta property="og:type" content="website" />
   <meta property="og:url" content="https://practx.io/hygiene.html" />
-  <meta property="og:image" content="https://practx.io/assets/logo.svg" />
+  <meta property="og:image" content="https://practx.io/assets/logo.png" />
   <meta name="twitter:card" content="summary" />
-  <link rel="icon" href="assets/logo.svg" type="image/svg+xml" />
+  <link rel="icon" href="assets/logo.png" type="image/png" />
   <link rel="stylesheet" href="assets/styles.css" />
   <script defer src="signup.js"></script>
 </head>
@@ -19,7 +19,7 @@
   <header>
     <nav>
       <a class="logo" href="/index.html">
-        <img src="assets/logo.svg" alt="Practx logo" width="32" height="32" />
+        <img src="assets/logo.png" alt="Practx logo" width="32" height="32" />
         <span>Practx</span>
       </a>
       <ul>

--- a/practx-swa/frontend/index.html
+++ b/practx-swa/frontend/index.html
@@ -9,9 +9,9 @@
   <meta property="og:description" content="Practx aligns practice management, equipment lifecycle, patient outreach, and franchise growth inside a unified dental brand system." />
   <meta property="og:type" content="website" />
   <meta property="og:url" content="https://practx.io/" />
-  <meta property="og:image" content="https://practx.io/assets/logo.svg" />
+  <meta property="og:image" content="https://practx.io/assets/logo.png" />
   <meta name="twitter:card" content="summary" />
-  <link rel="icon" href="assets/logo.svg" type="image/svg+xml" />
+  <link rel="icon" href="assets/logo.png" type="image/png" />
   <link rel="stylesheet" href="assets/styles.css" />
   <script defer src="signup.js"></script>
 </head>
@@ -19,7 +19,7 @@
   <header>
     <nav>
       <a class="logo" href="/index.html">
-        <img src="assets/logo.svg" alt="Practx logo" width="32" height="32" />
+        <img src="assets/logo.png" alt="Practx logo" width="32" height="32" />
         <span>Practx</span>
       </a>
       <ul>

--- a/practx-swa/frontend/leadership.html
+++ b/practx-swa/frontend/leadership.html
@@ -9,16 +9,16 @@
   <meta property="og:description" content="Leaders from clinical, operations, and technology unite to expand dental access." />
   <meta property="og:type" content="website" />
   <meta property="og:url" content="https://practx.io/leadership.html" />
-  <meta property="og:image" content="https://practx.io/assets/logo.svg" />
+  <meta property="og:image" content="https://practx.io/assets/logo.png" />
   <meta name="twitter:card" content="summary" />
-  <link rel="icon" href="assets/logo.svg" type="image/svg+xml" />
+  <link rel="icon" href="assets/logo.png" type="image/png" />
   <link rel="stylesheet" href="assets/styles.css" />
 </head>
 <body>
   <header>
     <nav>
       <a class="logo" href="/index.html">
-        <img src="assets/logo.svg" alt="Practx logo" width="32" height="32" />
+        <img src="assets/logo.png" alt="Practx logo" width="32" height="32" />
         <span>Practx</span>
       </a>
       <ul>

--- a/practx-swa/frontend/marketing.html
+++ b/practx-swa/frontend/marketing.html
@@ -9,16 +9,16 @@
   <meta property="og:description" content="Smart, scalable dental marketing — digital campaigns, co-branded hygiene kits, patient reactivation, and analytics." />
   <meta property="og:type" content="website" />
   <meta property="og:url" content="https://practx.io/marketing.html" />
-  <meta property="og:image" content="https://practx.io/assets/logo.svg" />
+  <meta property="og:image" content="https://practx.io/assets/logo.png" />
   <meta name="twitter:card" content="summary" />
-  <link rel="icon" href="assets/logo.svg" type="image/svg+xml" />
+  <link rel="icon" href="assets/logo.png" type="image/png" />
   <link rel="stylesheet" href="assets/styles.css" />
 </head>
 <body>
   <header>
     <nav>
       <a class="logo" href="/index.html">
-        <img src="assets/logo.svg" alt="Practx logo" width="32" height="32" />
+        <img src="assets/logo.png" alt="Practx logo" width="32" height="32" />
         <span>Practx</span>
       </a>
       <ul>

--- a/practx-swa/frontend/patient-outreach.html
+++ b/practx-swa/frontend/patient-outreach.html
@@ -9,16 +9,16 @@
   <meta property="og:description" content="Automate recalls, reminders, and education with human-sounding templates, two-way messaging, and actionable reporting." />
   <meta property="og:type" content="website" />
   <meta property="og:url" content="https://practx.io/patient-outreach.html" />
-  <meta property="og:image" content="https://practx.io/assets/logo.svg" />
+  <meta property="og:image" content="https://practx.io/assets/logo.png" />
   <meta name="twitter:card" content="summary" />
-  <link rel="icon" href="assets/logo.svg" type="image/svg+xml" />
+  <link rel="icon" href="assets/logo.png" type="image/png" />
   <link rel="stylesheet" href="assets/styles.css" />
 </head>
 <body>
   <header>
     <nav>
       <a class="logo" href="/index.html">
-        <img src="assets/logo.svg" alt="Practx logo" width="32" height="32" />
+        <img src="assets/logo.png" alt="Practx logo" width="32" height="32" />
         <span>Practx</span>
       </a>
       <ul>

--- a/practx-swa/frontend/practice-management.html
+++ b/practx-swa/frontend/practice-management.html
@@ -9,16 +9,16 @@
   <meta property="og:description" content="Run your entire dental practice from a secure, cloud-native command center with optional Clinic-in-a-Box hardware." />
   <meta property="og:type" content="website" />
   <meta property="og:url" content="https://practx.io/practice-management.html" />
-  <meta property="og:image" content="https://practx.io/assets/logo.svg" />
+  <meta property="og:image" content="https://practx.io/assets/logo.png" />
   <meta name="twitter:card" content="summary" />
-  <link rel="icon" href="assets/logo.svg" type="image/svg+xml" />
+  <link rel="icon" href="assets/logo.png" type="image/png" />
   <link rel="stylesheet" href="assets/styles.css" />
 </head>
 <body>
   <header>
     <nav>
       <a class="logo" href="/index.html">
-        <img src="assets/logo.svg" alt="Practx logo" width="32" height="32" />
+        <img src="assets/logo.png" alt="Practx logo" width="32" height="32" />
         <span>Practx</span>
       </a>
       <ul>

--- a/practx-swa/frontend/practx-service-franchise.html
+++ b/practx-swa/frontend/practx-service-franchise.html
@@ -9,16 +9,16 @@
   <meta property="og:description" content="Deliver next-day dental equipment service with Practx training, branding, and guaranteed demand." />
   <meta property="og:type" content="website" />
   <meta property="og:url" content="https://practx.io/practx-service-franchise.html" />
-  <meta property="og:image" content="https://practx.io/assets/logo.svg" />
+  <meta property="og:image" content="https://practx.io/assets/logo.png" />
   <meta name="twitter:card" content="summary" />
-  <link rel="icon" href="assets/logo.svg" type="image/svg+xml" />
+  <link rel="icon" href="assets/logo.png" type="image/png" />
   <link rel="stylesheet" href="assets/styles.css" />
 </head>
 <body>
   <header>
     <nav>
       <a class="logo" href="/index.html">
-        <img src="assets/logo.svg" alt="Practx logo" width="32" height="32" />
+        <img src="assets/logo.png" alt="Practx logo" width="32" height="32" />
         <span>Practx</span>
       </a>
       <ul>

--- a/practx-swa/frontend/procurement.html
+++ b/practx-swa/frontend/procurement.html
@@ -9,16 +9,16 @@
   <meta property="og:description" content="Automated dental supply subscriptions and Vendor‑Managed Inventory with real‑time tracking and predictable costs." />
   <meta property="og:type" content="website" />
   <meta property="og:url" content="https://practx.io/procurement.html" />
-  <meta property="og:image" content="https://practx.io/assets/logo.svg" />
+  <meta property="og:image" content="https://practx.io/assets/logo.png" />
   <meta name="twitter:card" content="summary" />
-  <link rel="icon" href="assets/logo.svg" type="image/svg+xml" />
+  <link rel="icon" href="assets/logo.png" type="image/png" />
   <link rel="stylesheet" href="assets/styles.css" />
 </head>
 <body>
   <header>
     <nav>
       <a class="logo" href="/index.html">
-        <img src="assets/logo.svg" alt="Practx logo" width="32" height="32" />
+        <img src="assets/logo.png" alt="Practx logo" width="32" height="32" />
         <span>Practx</span>
       </a>
       <ul>

--- a/practx-swa/frontend/smile-spa-franchise.html
+++ b/practx-swa/frontend/smile-spa-franchise.html
@@ -9,16 +9,16 @@
   <meta property="og:description" content="Open a Practx Smile Spa — a flexible hygiene studio backed by the Practx brand system and go-to-market support." />
   <meta property="og:type" content="website" />
   <meta property="og:url" content="https://practx.io/smile-spa-franchise.html" />
-  <meta property="og:image" content="https://practx.io/assets/logo.svg" />
+  <meta property="og:image" content="https://practx.io/assets/logo.png" />
   <meta name="twitter:card" content="summary" />
-  <link rel="icon" href="assets/logo.svg" type="image/svg+xml" />
+  <link rel="icon" href="assets/logo.png" type="image/png" />
   <link rel="stylesheet" href="assets/styles.css" />
 </head>
 <body>
   <header>
     <nav>
       <a class="logo" href="/index.html">
-        <img src="assets/logo.svg" alt="Practx logo" width="32" height="32" />
+        <img src="assets/logo.png" alt="Practx logo" width="32" height="32" />
         <span>Practx</span>
       </a>
       <ul>

--- a/practx-swa/frontend/staffing.html
+++ b/practx-swa/frontend/staffing.html
@@ -9,16 +9,16 @@
   <meta property="og:description" content="Qualified hygienists, assistants, and dentists for temporary and contract roles — vetted, credentialed, and ready." />
   <meta property="og:type" content="website" />
   <meta property="og:url" content="https://practx.io/staffing.html" />
-  <meta property="og:image" content="https://practx.io/assets/logo.svg" />
+  <meta property="og:image" content="https://practx.io/assets/logo.png" />
   <meta name="twitter:card" content="summary" />
-  <link rel="icon" href="assets/logo.svg" type="image/svg+xml" />
+  <link rel="icon" href="assets/logo.png" type="image/png" />
   <link rel="stylesheet" href="assets/styles.css" />
 </head>
 <body>
   <header>
     <nav>
       <a class="logo" href="/index.html">
-        <img src="assets/logo.svg" alt="Practx logo" width="32" height="32" />
+        <img src="assets/logo.png" alt="Practx logo" width="32" height="32" />
         <span>Practx</span>
       </a>
       <ul>

--- a/practx-swa/frontend/thank-you.html
+++ b/practx-swa/frontend/thank-you.html
@@ -9,16 +9,16 @@
   <meta property="og:description" content="Thank you for connecting with Practx. We’ll be in touch soon." />
   <meta property="og:type" content="website" />
   <meta property="og:url" content="https://practx.io/thank-you.html" />
-  <meta property="og:image" content="https://practx.io/assets/logo.svg" />
+  <meta property="og:image" content="https://practx.io/assets/logo.png" />
   <meta name="twitter:card" content="summary" />
-  <link rel="icon" href="assets/logo.svg" type="image/svg+xml" />
+  <link rel="icon" href="assets/logo.png" type="image/png" />
   <link rel="stylesheet" href="assets/styles.css" />
 </head>
 <body>
   <header>
     <nav>
       <a class="logo" href="/index.html">
-        <img src="assets/logo.svg" alt="Practx logo" width="32" height="32" />
+        <img src="assets/logo.png" alt="Practx logo" width="32" height="32" />
         <span>Practx</span>
       </a>
       <ul>


### PR DESCRIPTION
## Summary
- replace Azure Static Web App HTML pages to reference logo.png instead of logo.svg for logos and favicons
- update SWA README to reflect the new PNG asset path

## Testing
- not run (not applicable)


------
https://chatgpt.com/codex/tasks/task_e_68e65f5a05048323992c9b73a105e22e