### PR TITLE
Update header logo sizing for Practx SWA site

### DIFF
--- a/practx-swa/frontend/about.html
+++ b/practx-swa/frontend/about.html
@@ -18,8 +18,7 @@
   <header>
     <nav>
       <a class="logo" href="/index.html">
-        <img src="assets/logo.png" alt="Practx logo" width="32" height="32" />
-        <span>Practx</span>
+        <img src="assets/logo.png" alt="Practx logo" height="60" />
       </a>
       <ul>
         <li><a href="/practice-management.html">Practice Management</a></li>

--- a/practx-swa/frontend/admin.html
+++ b/practx-swa/frontend/admin.html
@@ -18,8 +18,7 @@
   <header>
     <nav>
       <a class="logo" href="/index.html">
-        <img src="assets/logo.png" alt="Practx logo" width="32" height="32" />
-        <span>Practx</span>
+        <img src="assets/logo.png" alt="Practx logo" height="60" />
       </a>
       <ul>
         <li><a href="/practice-management.html">Practice Management</a></li>

--- a/practx-swa/frontend/assets/styles.css
+++ b/practx-swa/frontend/assets/styles.css
@@ -55,6 +55,11 @@ nav {
   color: var(--color-primary);
 }
 
+.logo img {
+  height: 60px;
+  width: auto;
+}
+
 nav ul {
   display: flex;
   gap: 1.25rem;

--- a/practx-swa/frontend/careers.html
+++ b/practx-swa/frontend/careers.html
@@ -18,8 +18,7 @@
   <header>
     <nav>
       <a class="logo" href="/index.html">
-        <img src="assets/logo.png" alt="Practx logo" width="32" height="32" />
-        <span>Practx</span>
+        <img src="assets/logo.png" alt="Practx logo" height="60" />
       </a>
       <ul>
         <li><a href="/practice-management.html">Practice Management</a></li>

--- a/practx-swa/frontend/contact.html
+++ b/practx-swa/frontend/contact.html
@@ -18,8 +18,7 @@
   <header>
     <nav>
       <a class="logo" href="/index.html">
-        <img src="assets/logo.png" alt="Practx logo" width="32" height="32" />
-        <span>Practx</span>
+        <img src="assets/logo.png" alt="Practx logo" height="60" />
       </a>
       <ul>
         <li><a href="/practice-management.html">Practice Management</a></li>

--- a/practx-swa/frontend/equipment-management.html
+++ b/practx-swa/frontend/equipment-management.html
@@ -18,8 +18,7 @@
   <header>
     <nav>
       <a class="logo" href="/index.html">
-        <img src="assets/logo.png" alt="Practx logo" width="32" height="32" />
-        <span>Practx</span>
+        <img src="assets/logo.png" alt="Practx logo" height="60" />
       </a>
       <ul>
         <li><a href="/practice-management.html">Practice Management</a></li>

--- a/practx-swa/frontend/franchise.html
+++ b/practx-swa/frontend/franchise.html
@@ -19,8 +19,7 @@
   <header>
     <nav>
       <a class="logo" href="/index.html">
-        <img src="assets/logo.png" alt="Practx logo" width="32" height="32" />
-        <span>Practx</span>
+        <img src="assets/logo.png" alt="Practx logo" height="60" />
       </a>
       <ul>
         <li><a href="/practice-management.html">Practice Management</a></li>

--- a/practx-swa/frontend/hygiene.html
+++ b/practx-swa/frontend/hygiene.html
@@ -19,8 +19,7 @@
   <header>
     <nav>
       <a class="logo" href="/index.html">
-        <img src="assets/logo.png" alt="Practx logo" width="32" height="32" />
-        <span>Practx</span>
+        <img src="assets/logo.png" alt="Practx logo" height="60" />
       </a>
       <ul>
         <li><a href="/practice-management.html">Practice Management</a></li>

--- a/practx-swa/frontend/index.html
+++ b/practx-swa/frontend/index.html
@@ -19,8 +19,7 @@
   <header>
     <nav>
       <a class="logo" href="/index.html">
-        <img src="assets/logo.png" alt="Practx logo" width="32" height="32" />
-        <span>Practx</span>
+        <img src="assets/logo.png" alt="Practx logo" height="60" />
       </a>
       <ul>
         <li><a href="/practice-management.html">Practice Management</a></li>

--- a/practx-swa/frontend/leadership.html
+++ b/practx-swa/frontend/leadership.html
@@ -18,8 +18,7 @@
   <header>
     <nav>
       <a class="logo" href="/index.html">
-        <img src="assets/logo.png" alt="Practx logo" width="32" height="32" />
-        <span>Practx</span>
+        <img src="assets/logo.png" alt="Practx logo" height="60" />
       </a>
       <ul>
         <li><a href="/practice-management.html">Practice Management</a></li>

--- a/practx-swa/frontend/marketing.html
+++ b/practx-swa/frontend/marketing.html
@@ -18,8 +18,7 @@
   <header>
     <nav>
       <a class="logo" href="/index.html">
-        <img src="assets/logo.png" alt="Practx logo" width="32" height="32" />
-        <span>Practx</span>
+        <img src="assets/logo.png" alt="Practx logo" height="60" />
       </a>
       <ul>
         <li><a href="/practice-management.html">Practice Management</a></li>

--- a/practx-swa/frontend/patient-outreach.html
+++ b/practx-swa/frontend/patient-outreach.html
@@ -18,8 +18,7 @@
   <header>
     <nav>
       <a class="logo" href="/index.html">
-        <img src="assets/logo.png" alt="Practx logo" width="32" height="32" />
-        <span>Practx</span>
+        <img src="assets/logo.png" alt="Practx logo" height="60" />
       </a>
       <ul>
         <li><a href="/practice-management.html">Practice Management</a></li>

--- a/practx-swa/frontend/practice-management.html
+++ b/practx-swa/frontend/practice-management.html
@@ -18,8 +18,7 @@
   <header>
     <nav>
       <a class="logo" href="/index.html">
-        <img src="assets/logo.png" alt="Practx logo" width="32" height="32" />
-        <span>Practx</span>
+        <img src="assets/logo.png" alt="Practx logo" height="60" />
       </a>
       <ul>
         <li><a class="active" href="/practice-management.html">Practice Management</a></li>

--- a/practx-swa/frontend/practx-service-franchise.html
+++ b/practx-swa/frontend/practx-service-franchise.html
@@ -18,8 +18,7 @@
   <header>
     <nav>
       <a class="logo" href="/index.html">
-        <img src="assets/logo.png" alt="Practx logo" width="32" height="32" />
-        <span>Practx</span>
+        <img src="assets/logo.png" alt="Practx logo" height="60" />
       </a>
       <ul>
         <li><a href="/practice-management.html">Practice Management</a></li>

--- a/practx-swa/frontend/procurement.html
+++ b/practx-swa/frontend/procurement.html
@@ -18,8 +18,7 @@
   <header>
     <nav>
       <a class="logo" href="/index.html">
-        <img src="assets/logo.png" alt="Practx logo" width="32" height="32" />
-        <span>Practx</span>
+        <img src="assets/logo.png" alt="Practx logo" height="60" />
       </a>
       <ul>
         <li><a href="/practice-management.html">Practice Management</a></li>

--- a/practx-swa/frontend/smile-spa-franchise.html
+++ b/practx-swa/frontend/smile-spa-franchise.html
@@ -18,8 +18,7 @@
   <header>
     <nav>
       <a class="logo" href="/index.html">
-        <img src="assets/logo.png" alt="Practx logo" width="32" height="32" />
-        <span>Practx</span>
+        <img src="assets/logo.png" alt="Practx logo" height="60" />
       </a>
       <ul>
         <li><a href="/practice-management.html">Practice Management</a></li>

--- a/practx-swa/frontend/staffing.html
+++ b/practx-swa/frontend/staffing.html
@@ -18,8 +18,7 @@
   <header>
     <nav>
       <a class="logo" href="/index.html">
-        <img src="assets/logo.png" alt="Practx logo" width="32" height="32" />
-        <span>Practx</span>
+        <img src="assets/logo.png" alt="Practx logo" height="60" />
       </a>
       <ul>
         <li><a href="/practice-management.html">Practice Management</a></li>

--- a/practx-swa/frontend/thank-you.html
+++ b/practx-swa/frontend/thank-you.html
@@ -18,8 +18,7 @@
   <header>
     <nav>
       <a class="logo" href="/index.html">
-        <img src="assets/logo.png" alt="Practx logo" width="32" height="32" />
-        <span>Practx</span>
+        <img src="assets/logo.png" alt="Practx logo" height="60" />
       </a>
       <ul>
         <li><a href="/practice-management.html">Practice Management</a></li>


### PR DESCRIPTION
## Summary
- enlarge the header logo to display at 60px tall across the Practx SWA frontend pages while keeping the original aspect ratio
- remove the redundant Practx text label beside the logo and centralize sizing through CSS

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68e661bdda508323ac34ad4d0b04a4df