### PR TITLE
Update navigation pillar labels to new terminology

### DIFF
--- a/practx-swa/frontend/about.html
+++ b/practx-swa/frontend/about.html
@@ -21,9 +21,9 @@
         <img src="assets/logo.png" alt="Practx logo" height="60" />
       </a>
       <ul>
-        <li><a href="/practice-management.html">Practice Management</a></li>
-        <li><a href="/equipment-management.html">Equipment Management</a></li>
-        <li><a href="/patient-outreach.html">Patient Outreach</a></li>
+        <li><a href="/practice-management.html">Manage Practices</a></li>
+        <li><a href="/equipment-management.html">Manage Equipment</a></li>
+        <li><a href="/patient-outreach.html">Connect to Patients</a></li>
         <li><a href="/smile-spa-franchise.html">Expand Access</a></li>
         <li><a href="/practx-service-franchise.html">Ensure Uptime</a></li>
       </ul>

--- a/practx-swa/frontend/admin.html
+++ b/practx-swa/frontend/admin.html
@@ -21,9 +21,9 @@
         <img src="assets/logo.png" alt="Practx logo" height="60" />
       </a>
       <ul>
-        <li><a href="/practice-management.html">Practice Management</a></li>
-        <li><a href="/equipment-management.html">Equipment Management</a></li>
-        <li><a href="/patient-outreach.html">Patient Outreach</a></li>
+        <li><a href="/practice-management.html">Manage Practices</a></li>
+        <li><a href="/equipment-management.html">Manage Equipment</a></li>
+        <li><a href="/patient-outreach.html">Connect to Patients</a></li>
         <li><a href="/smile-spa-franchise.html">Expand Access</a></li>
         <li><a href="/practx-service-franchise.html">Ensure Uptime</a></li>
       </ul>

--- a/practx-swa/frontend/assets/styles.css
+++ b/practx-swa/frontend/assets/styles.css
@@ -179,6 +179,19 @@ main {
 
 .pillars-overview {
   margin-bottom: 4rem;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+}
+
+@media (max-width: 960px) {
+  .pillars-overview {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+}
+
+@media (max-width: 640px) {
+  .pillars-overview {
+    grid-template-columns: 1fr;
+  }
 }
 
 .card {

--- a/practx-swa/frontend/careers.html
+++ b/practx-swa/frontend/careers.html
@@ -21,9 +21,9 @@
         <img src="assets/logo.png" alt="Practx logo" height="60" />
       </a>
       <ul>
-        <li><a href="/practice-management.html">Practice Management</a></li>
-        <li><a href="/equipment-management.html">Equipment Management</a></li>
-        <li><a href="/patient-outreach.html">Patient Outreach</a></li>
+        <li><a href="/practice-management.html">Manage Practices</a></li>
+        <li><a href="/equipment-management.html">Manage Equipment</a></li>
+        <li><a href="/patient-outreach.html">Connect to Patients</a></li>
         <li><a href="/smile-spa-franchise.html">Expand Access</a></li>
         <li><a href="/practx-service-franchise.html">Ensure Uptime</a></li>
       </ul>

--- a/practx-swa/frontend/contact.html
+++ b/practx-swa/frontend/contact.html
@@ -21,9 +21,9 @@
         <img src="assets/logo.png" alt="Practx logo" height="60" />
       </a>
       <ul>
-        <li><a href="/practice-management.html">Practice Management</a></li>
-        <li><a href="/equipment-management.html">Equipment Management</a></li>
-        <li><a href="/patient-outreach.html">Patient Outreach</a></li>
+        <li><a href="/practice-management.html">Manage Practices</a></li>
+        <li><a href="/equipment-management.html">Manage Equipment</a></li>
+        <li><a href="/patient-outreach.html">Connect to Patients</a></li>
         <li><a href="/smile-spa-franchise.html">Expand Access</a></li>
         <li><a href="/practx-service-franchise.html">Ensure Uptime</a></li>
       </ul>

--- a/practx-swa/frontend/equipment-management.html
+++ b/practx-swa/frontend/equipment-management.html
@@ -21,9 +21,9 @@
         <img src="assets/logo.png" alt="Practx logo" height="60" />
       </a>
       <ul>
-        <li><a href="/practice-management.html">Practice Management</a></li>
-        <li><a class="active" href="/equipment-management.html">Equipment Management</a></li>
-        <li><a href="/patient-outreach.html">Patient Outreach</a></li>
+        <li><a href="/practice-management.html">Manage Practices</a></li>
+        <li><a class="active" href="/equipment-management.html">Manage Equipment</a></li>
+        <li><a href="/patient-outreach.html">Connect to Patients</a></li>
         <li><a href="/smile-spa-franchise.html">Expand Access</a></li>
         <li><a href="/practx-service-franchise.html">Ensure Uptime</a></li>
       </ul>

--- a/practx-swa/frontend/franchise.html
+++ b/practx-swa/frontend/franchise.html
@@ -22,9 +22,9 @@
         <img src="assets/logo.png" alt="Practx logo" height="60" />
       </a>
       <ul>
-        <li><a href="/practice-management.html">Practice Management</a></li>
-        <li><a href="/equipment-management.html">Equipment Management</a></li>
-        <li><a href="/patient-outreach.html">Patient Outreach</a></li>
+        <li><a href="/practice-management.html">Manage Practices</a></li>
+        <li><a href="/equipment-management.html">Manage Equipment</a></li>
+        <li><a href="/patient-outreach.html">Connect to Patients</a></li>
         <li><a href="/smile-spa-franchise.html">Expand Access</a></li>
         <li><a href="/practx-service-franchise.html">Ensure Uptime</a></li>
       </ul>

--- a/practx-swa/frontend/hygiene.html
+++ b/practx-swa/frontend/hygiene.html
@@ -22,9 +22,9 @@
         <img src="assets/logo.png" alt="Practx logo" height="60" />
       </a>
       <ul>
-        <li><a href="/practice-management.html">Practice Management</a></li>
-        <li><a href="/equipment-management.html">Equipment Management</a></li>
-        <li><a href="/patient-outreach.html">Patient Outreach</a></li>
+        <li><a href="/practice-management.html">Manage Practices</a></li>
+        <li><a href="/equipment-management.html">Manage Equipment</a></li>
+        <li><a href="/patient-outreach.html">Connect to Patients</a></li>
         <li><a href="/smile-spa-franchise.html">Expand Access</a></li>
         <li><a href="/practx-service-franchise.html">Ensure Uptime</a></li>
       </ul>

--- a/practx-swa/frontend/index.html
+++ b/practx-swa/frontend/index.html
@@ -22,9 +22,9 @@
         <img src="assets/logo.png" alt="Practx logo" height="60" />
       </a>
       <ul>
-        <li><a href="/practice-management.html">Practice Management</a></li>
-        <li><a href="/equipment-management.html">Equipment Management</a></li>
-        <li><a href="/patient-outreach.html">Patient Outreach</a></li>
+        <li><a href="/practice-management.html">Manage Practices</a></li>
+        <li><a href="/equipment-management.html">Manage Equipment</a></li>
+        <li><a href="/patient-outreach.html">Connect to Patients</a></li>
         <li><a href="/smile-spa-franchise.html">Expand Access</a></li>
         <li><a href="/practx-service-franchise.html">Ensure Uptime</a></li>
       </ul>
@@ -42,17 +42,17 @@
 
     <section class="features pillars-overview" aria-label="Practx offerings">
       <article class="card">
-        <h3>Practice Management</h3>
+        <h3>Manage Practices</h3>
         <p>Secure, cloud-native operations with optional Clinic-in-a-Box hardware.</p>
         <a class="text-link" href="/practice-management.html">Explore Practice Management →</a>
       </article>
       <article class="card">
-        <h3>Equipment Management</h3>
+        <h3>Manage Equipment</h3>
         <p>Lifecycle analytics, TPM programs, and coordinated service for every operatory.</p>
         <a class="text-link" href="/equipment-management.html">Discover Equipment Management →</a>
       </article>
       <article class="card">
-        <h3>Patient Outreach</h3>
+        <h3>Connect to Patients</h3>
         <p>AI-assisted communications that sound human while filling the schedule.</p>
         <a class="text-link" href="/patient-outreach.html">See Patient Outreach →</a>
       </article>

--- a/practx-swa/frontend/leadership.html
+++ b/practx-swa/frontend/leadership.html
@@ -21,9 +21,9 @@
         <img src="assets/logo.png" alt="Practx logo" height="60" />
       </a>
       <ul>
-        <li><a href="/practice-management.html">Practice Management</a></li>
-        <li><a href="/equipment-management.html">Equipment Management</a></li>
-        <li><a href="/patient-outreach.html">Patient Outreach</a></li>
+        <li><a href="/practice-management.html">Manage Practices</a></li>
+        <li><a href="/equipment-management.html">Manage Equipment</a></li>
+        <li><a href="/patient-outreach.html">Connect to Patients</a></li>
         <li><a href="/smile-spa-franchise.html">Expand Access</a></li>
         <li><a href="/practx-service-franchise.html">Ensure Uptime</a></li>
       </ul>

--- a/practx-swa/frontend/marketing.html
+++ b/practx-swa/frontend/marketing.html
@@ -21,9 +21,9 @@
         <img src="assets/logo.png" alt="Practx logo" height="60" />
       </a>
       <ul>
-        <li><a href="/practice-management.html">Practice Management</a></li>
-        <li><a href="/equipment-management.html">Equipment Management</a></li>
-        <li><a href="/patient-outreach.html">Patient Outreach</a></li>
+        <li><a href="/practice-management.html">Manage Practices</a></li>
+        <li><a href="/equipment-management.html">Manage Equipment</a></li>
+        <li><a href="/patient-outreach.html">Connect to Patients</a></li>
         <li><a href="/smile-spa-franchise.html">Expand Access</a></li>
         <li><a href="/practx-service-franchise.html">Ensure Uptime</a></li>
       </ul>

--- a/practx-swa/frontend/patient-outreach.html
+++ b/practx-swa/frontend/patient-outreach.html
@@ -21,9 +21,9 @@
         <img src="assets/logo.png" alt="Practx logo" height="60" />
       </a>
       <ul>
-        <li><a href="/practice-management.html">Practice Management</a></li>
-        <li><a href="/equipment-management.html">Equipment Management</a></li>
-        <li><a class="active" href="/patient-outreach.html">Patient Outreach</a></li>
+        <li><a href="/practice-management.html">Manage Practices</a></li>
+        <li><a href="/equipment-management.html">Manage Equipment</a></li>
+        <li><a class="active" href="/patient-outreach.html">Connect to Patients</a></li>
         <li><a href="/smile-spa-franchise.html">Expand Access</a></li>
         <li><a href="/practx-service-franchise.html">Ensure Uptime</a></li>
       </ul>

--- a/practx-swa/frontend/practice-management.html
+++ b/practx-swa/frontend/practice-management.html
@@ -21,9 +21,9 @@
         <img src="assets/logo.png" alt="Practx logo" height="60" />
       </a>
       <ul>
-        <li><a class="active" href="/practice-management.html">Practice Management</a></li>
-        <li><a href="/equipment-management.html">Equipment Management</a></li>
-        <li><a href="/patient-outreach.html">Patient Outreach</a></li>
+        <li><a class="active" href="/practice-management.html">Manage Practices</a></li>
+        <li><a href="/equipment-management.html">Manage Equipment</a></li>
+        <li><a href="/patient-outreach.html">Connect to Patients</a></li>
         <li><a href="/smile-spa-franchise.html">Expand Access</a></li>
         <li><a href="/practx-service-franchise.html">Ensure Uptime</a></li>
       </ul>

--- a/practx-swa/frontend/practx-service-franchise.html
+++ b/practx-swa/frontend/practx-service-franchise.html
@@ -21,9 +21,9 @@
         <img src="assets/logo.png" alt="Practx logo" height="60" />
       </a>
       <ul>
-        <li><a href="/practice-management.html">Practice Management</a></li>
-        <li><a href="/equipment-management.html">Equipment Management</a></li>
-        <li><a href="/patient-outreach.html">Patient Outreach</a></li>
+        <li><a href="/practice-management.html">Manage Practices</a></li>
+        <li><a href="/equipment-management.html">Manage Equipment</a></li>
+        <li><a href="/patient-outreach.html">Connect to Patients</a></li>
         <li><a href="/smile-spa-franchise.html">Expand Access</a></li>
         <li><a class="active" href="/practx-service-franchise.html">Ensure Uptime</a></li>
       </ul>

--- a/practx-swa/frontend/procurement.html
+++ b/practx-swa/frontend/procurement.html
@@ -21,9 +21,9 @@
         <img src="assets/logo.png" alt="Practx logo" height="60" />
       </a>
       <ul>
-        <li><a href="/practice-management.html">Practice Management</a></li>
-        <li><a href="/equipment-management.html">Equipment Management</a></li>
-        <li><a href="/patient-outreach.html">Patient Outreach</a></li>
+        <li><a href="/practice-management.html">Manage Practices</a></li>
+        <li><a href="/equipment-management.html">Manage Equipment</a></li>
+        <li><a href="/patient-outreach.html">Connect to Patients</a></li>
         <li><a href="/smile-spa-franchise.html">Expand Access</a></li>
         <li><a href="/practx-service-franchise.html">Ensure Uptime</a></li>
       </ul>

--- a/practx-swa/frontend/smile-spa-franchise.html
+++ b/practx-swa/frontend/smile-spa-franchise.html
@@ -21,9 +21,9 @@
         <img src="assets/logo.png" alt="Practx logo" height="60" />
       </a>
       <ul>
-        <li><a href="/practice-management.html">Practice Management</a></li>
-        <li><a href="/equipment-management.html">Equipment Management</a></li>
-        <li><a href="/patient-outreach.html">Patient Outreach</a></li>
+        <li><a href="/practice-management.html">Manage Practices</a></li>
+        <li><a href="/equipment-management.html">Manage Equipment</a></li>
+        <li><a href="/patient-outreach.html">Connect to Patients</a></li>
         <li><a class="active" href="/smile-spa-franchise.html">Expand Access</a></li>
         <li><a href="/practx-service-franchise.html">Ensure Uptime</a></li>
       </ul>

--- a/practx-swa/frontend/staffing.html
+++ b/practx-swa/frontend/staffing.html
@@ -21,9 +21,9 @@
         <img src="assets/logo.png" alt="Practx logo" height="60" />
       </a>
       <ul>
-        <li><a href="/practice-management.html">Practice Management</a></li>
-        <li><a href="/equipment-management.html">Equipment Management</a></li>
-        <li><a href="/patient-outreach.html">Patient Outreach</a></li>
+        <li><a href="/practice-management.html">Manage Practices</a></li>
+        <li><a href="/equipment-management.html">Manage Equipment</a></li>
+        <li><a href="/patient-outreach.html">Connect to Patients</a></li>
         <li><a href="/smile-spa-franchise.html">Expand Access</a></li>
         <li><a href="/practx-service-franchise.html">Ensure Uptime</a></li>
       </ul>

--- a/practx-swa/frontend/thank-you.html
+++ b/practx-swa/frontend/thank-you.html
@@ -21,9 +21,9 @@
         <img src="assets/logo.png" alt="Practx logo" height="60" />
       </a>
       <ul>
-        <li><a href="/practice-management.html">Practice Management</a></li>
-        <li><a href="/equipment-management.html">Equipment Management</a></li>
-        <li><a href="/patient-outreach.html">Patient Outreach</a></li>
+        <li><a href="/practice-management.html">Manage Practices</a></li>
+        <li><a href="/equipment-management.html">Manage Equipment</a></li>
+        <li><a href="/patient-outreach.html">Connect to Patients</a></li>
         <li><a href="/smile-spa-franchise.html">Expand Access</a></li>
         <li><a href="/practx-service-franchise.html">Ensure Uptime</a></li>
       </ul>


### PR DESCRIPTION
## Summary
- update the primary navigation links to use the Manage Practices, Manage Equipment, and Connect to Patients terminology across all marketing pages

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68e6673356b08323925b271c5e68def5