### PR TITLE
Add service franchise support pillar to about page

### DIFF
--- a/practx-swa/frontend/about.html
+++ b/practx-swa/frontend/about.html
@@ -69,7 +69,7 @@
     <section class="about-section">
       <div class="section-heading">
         <span class="eyebrow">The Practx Framework</span>
-        <h2>Four pillars that extend access.</h2>
+        <h2>Five pillars that extend access.</h2>
       </div>
       <div class="framework-grid">
         <article class="card">
@@ -87,6 +87,10 @@
         <article class="card">
           <h3>Access Expansion</h3>
           <p>Practx believes oral health should meet people where they are. Through new care models, technology-driven partnerships, and community-based initiatives, we’re reimagining how and where patients receive care — extending access, expanding opportunity, and empowering providers to reach beyond the traditional operatory.</p>
+        </article>
+        <article class="card">
+          <h3>Support &amp; Service Franchise</h3>
+          <p>Our service franchise model keeps every practice ready to serve through next-day repairs, preventative maintenance, and on-demand expertise. Local franchise partners operate with Practx training, technology, and logistics, delivering reliable uptime that protects the patient experience.</p>
         </article>
       </div>
     </section>

--- a/practx-swa/frontend/about.html
+++ b/practx-swa/frontend/about.html
@@ -89,8 +89,8 @@
           <p>Practx believes oral health should meet people where they are. Through new care models, technology-driven partnerships, and community-based initiatives, we’re reimagining how and where patients receive care — extending access, expanding opportunity, and empowering providers to reach beyond the traditional operatory.</p>
         </article>
         <article class="card">
-          <h3>Support &amp; Service Franchise</h3>
-          <p>Our service franchise model keeps every practice ready to serve through next-day repairs, preventative maintenance, and on-demand expertise. Local franchise partners operate with Practx training, technology, and logistics, delivering reliable uptime that protects the patient experience.</p>
+          <h3>Local Support</h3>
+          <p>Our service franchise model keeps every practice ready to serve through next-day repairs, preventative maintenance, and on-demand expertise. Local franchise partners operate with Practx training, technology, and logistics, delivering reliable uptime that protects the patient experience, no matter where a practice is located.</p>
         </article>
       </div>
     </section>


### PR DESCRIPTION
## Summary
- update the Practx Framework heading to reflect five pillars
- add a Support & Service Franchise card describing the service franchise model

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68e672c07d848323af382d2d4ff1dc23