### PR TITLE
Scope SWA GitHub Actions to SWA-related changes

### DIFF
--- a/.github/workflows/azure-static-web-apps-delightful-ground-06c5f621e.yml
+++ b/.github/workflows/azure-static-web-apps-delightful-ground-06c5f621e.yml
@@ -2,14 +2,14 @@ name: Azure Static Web Apps CI/CD Delightful
 
 on:
   push:
-    branches:
+    branches-ignore:
       - main
     paths:
       - 'practx-swa/**'
       - 'infra/modules/swa/**'
       - '.github/workflows/azure-static-web-apps*.yml'
   pull_request:
-    types: [opened, synchronize, reopened, closed]
+    types: [closed]
     paths:
       - 'practx-swa/**'
       - 'infra/modules/swa/**'
@@ -17,7 +17,7 @@ on:
 
 jobs:
   build_and_deploy_job:
-    if: github.event_name == 'push' || (github.event_name == 'pull_request' && github.event.action != 'closed')
+    if: github.event_name == 'push'
     runs-on: ubuntu-latest
     name: Build and Deploy Job
     steps:

--- a/.github/workflows/azure-static-web-apps-delightful-ground-06c5f621e.yml
+++ b/.github/workflows/azure-static-web-apps-delightful-ground-06c5f621e.yml
@@ -2,6 +2,8 @@ name: Azure Static Web Apps CI/CD Delightful
 
 on:
   push:
+    branches:
+      - main
     paths:
       - 'practx-swa/**'
       - 'infra/modules/swa/**'

--- a/.github/workflows/azure-static-web-apps-delightful-ground-06c5f621e.yml
+++ b/.github/workflows/azure-static-web-apps-delightful-ground-06c5f621e.yml
@@ -2,8 +2,16 @@ name: Azure Static Web Apps CI/CD Delightful
 
 on:
   push:
+    paths:
+      - 'practx-swa/**'
+      - 'infra/modules/swa/**'
+      - '.github/workflows/azure-static-web-apps*.yml'
   pull_request:
     types: [opened, synchronize, reopened, closed]
+    paths:
+      - 'practx-swa/**'
+      - 'infra/modules/swa/**'
+      - '.github/workflows/azure-static-web-apps*.yml'
 
 jobs:
   build_and_deploy_job:

--- a/.github/workflows/azure-static-web-apps-mango-moss-04bc3691e.yml
+++ b/.github/workflows/azure-static-web-apps-mango-moss-04bc3691e.yml
@@ -2,8 +2,16 @@ name: Azure Static Web Apps CI/CD Mango Moss
 
 on:
   push:
+    paths:
+      - 'practx-swa/**'
+      - 'infra/modules/swa/**'
+      - '.github/workflows/azure-static-web-apps*.yml'
   pull_request:
     types: [opened, synchronize, reopened, closed]
+    paths:
+      - 'practx-swa/**'
+      - 'infra/modules/swa/**'
+      - '.github/workflows/azure-static-web-apps*.yml'
 
 jobs:
   build_and_deploy_job:

--- a/.github/workflows/azure-static-web-apps-mango-moss-04bc3691e.yml
+++ b/.github/workflows/azure-static-web-apps-mango-moss-04bc3691e.yml
@@ -2,14 +2,14 @@ name: Azure Static Web Apps CI/CD Mango Moss
 
 on:
   push:
-    branches:
+    branches-ignore:
       - main
     paths:
       - 'practx-swa/**'
       - 'infra/modules/swa/**'
       - '.github/workflows/azure-static-web-apps*.yml'
   pull_request:
-    types: [opened, synchronize, reopened, closed]
+    types: [closed]
     paths:
       - 'practx-swa/**'
       - 'infra/modules/swa/**'
@@ -17,7 +17,7 @@ on:
 
 jobs:
   build_and_deploy_job:
-    if: github.event_name == 'push' || (github.event_name == 'pull_request' && github.event.action != 'closed')
+    if: github.event_name == 'push'
     runs-on: ubuntu-latest
     name: Build and Deploy Job
     steps:

--- a/.github/workflows/azure-static-web-apps-mango-moss-04bc3691e.yml
+++ b/.github/workflows/azure-static-web-apps-mango-moss-04bc3691e.yml
@@ -2,6 +2,8 @@ name: Azure Static Web Apps CI/CD Mango Moss
 
 on:
   push:
+    branches:
+      - main
     paths:
       - 'practx-swa/**'
       - 'infra/modules/swa/**'

--- a/.github/workflows/azure-static-web-apps.yml
+++ b/.github/workflows/azure-static-web-apps.yml
@@ -4,6 +4,15 @@ on:
   push:
     branches:
       - main
+    paths:
+      - 'practx-swa/**'
+      - 'infra/modules/swa/**'
+      - '.github/workflows/azure-static-web-apps*.yml'
+  pull_request:
+    paths:
+      - 'practx-swa/**'
+      - 'infra/modules/swa/**'
+      - '.github/workflows/azure-static-web-apps*.yml'
 
 jobs:
   build_and_deploy_job:

--- a/.github/workflows/azure-static-web-apps.yml
+++ b/.github/workflows/azure-static-web-apps.yml
@@ -1,14 +1,11 @@
 name: Azure Static Web Apps CI/CD Mango Hill
 
 on:
-  push:
+  pull_request:
     branches:
       - main
-    paths:
-      - 'practx-swa/**'
-      - 'infra/modules/swa/**'
-      - '.github/workflows/azure-static-web-apps*.yml'
-  pull_request:
+    types:
+      - closed
     paths:
       - 'practx-swa/**'
       - 'infra/modules/swa/**'
@@ -16,11 +13,13 @@ on:
 
 jobs:
   build_and_deploy_job:
+    if: github.event.pull_request.merged == true
     runs-on: ubuntu-latest
     name: Build and Deploy Job
     steps:
       - uses: actions/checkout@v3
         with:
+          ref: ${{ github.event.pull_request.base.ref }}
           submodules: true
           lfs: false
       - name: Build And Deploy


### PR DESCRIPTION
## Summary
- restrict all Azure Static Web Apps workflows to run only when SWA application or infrastructure files change
- include workflow file updates in the path filters so configuration edits still trigger the pipelines

## Testing
- not run (workflow change)


------
https://chatgpt.com/codex/tasks/task_e_68fa144ddcb483239753796be0995dd2