### PR TITLE
Fix CI tests for practx-equipment-api (.NET 8)

### DIFF
--- a/.github/workflows/deploy-equipment-api.yml
+++ b/.github/workflows/deploy-equipment-api.yml
@@ -50,8 +50,26 @@ jobs:
       - name: Build API
         run: dotnet build src/Practx.Equipment.Api/Practx.Equipment.Api.csproj -c Release --no-restore
 
+      - name: Dotnet info (diag)
+        run: dotnet --info
+
+      - name: Verify test artifacts (diag)
+        run: |
+          ls -la tests/Practx.Equipment.Api.Tests || true
+          ls -la tests/Practx.Equipment.Api.Tests/bin/Release/net8.0 || true
+          cat tests/Practx.Equipment.Api.Tests/Practx.Equipment.Api.Tests.csproj || true
+
       - name: Run tests
-        run: dotnet test tests/Practx.Equipment.Api.Tests/Practx.Equipment.Api.Tests.csproj -c Release --no-build
+        run: |
+          set -euo pipefail
+          dotnet test tests/Practx.Equipment.Api.Tests/Practx.Equipment.Api.Tests.csproj -c Release --no-build --logger "console;verbosity=normal" && exit 0
+          echo "dotnet test failed; attempting fallback with dotnet vstest..."
+          DLL="tests/Practx.Equipment.Api.Tests/bin/Release/net8.0/Practx.Equipment.Api.Tests.dll"
+          if [ ! -f "$DLL" ]; then
+            echo "Expected test DLL not found at $DLL"
+            exit 1
+          fi
+          dotnet vstest "$DLL" --Platform:x64 --logger:"console;verbosity=normal"
 
       - name: Publish artifact
         run: dotnet publish src/Practx.Equipment.Api/Practx.Equipment.Api.csproj -c Release -o publish

--- a/practx-equipment-api/tests/Practx.Equipment.Api.Tests/Practx.Equipment.Api.Tests.csproj
+++ b/practx-equipment-api/tests/Practx.Equipment.Api.Tests/Practx.Equipment.Api.Tests.csproj
@@ -7,8 +7,9 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="8.0.8" />
-    <PackageReference Include="xunit" Version="2.5.3" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.3">
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.11.1" />
+    <PackageReference Include="xunit" Version="2.7.0" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.7">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>


### PR DESCRIPTION
## Root Cause
- The test project still targeted older test packages, so `dotnet test` on .NET 8 runners produced an invalid dll argument error from the outdated VSTest adapter.

## Changes
- Updated the Practx.Equipment.Api.Tests project to Microsoft.NET.Test.Sdk 17.11.1 with the latest xUnit packages compatible with .NET 8.
- Hardened the GitHub Actions test step with diagnostic logging and a `dotnet vstest` fallback while leaving the rest of the pipeline untouched.

## How to Revert
- Revert commit 88fad71 and commit b353276 to restore the prior package versions and workflow step.


------
https://chatgpt.com/codex/tasks/task_e_68fa56a1fdcc8323a2855b1d82f2a3f3