### PR TITLE
Validate test project path and align test steps to repo root in deploy workflow

### DIFF
--- a/.github/workflows/deploy-equipment-api.yml
+++ b/.github/workflows/deploy-equipment-api.yml
@@ -54,22 +54,21 @@ jobs:
         run: dotnet --info
 
       - name: Verify test artifacts (diag)
+        working-directory: .
         run: |
-          ls -la tests/Practx.Equipment.Api.Tests || true
-          ls -la tests/Practx.Equipment.Api.Tests/bin/Release/net8.0 || true
-          cat tests/Practx.Equipment.Api.Tests/Practx.Equipment.Api.Tests.csproj || true
-
-      - name: Run tests
-        run: |
-          set -euo pipefail
-          dotnet test tests/Practx.Equipment.Api.Tests/Practx.Equipment.Api.Tests.csproj -c Release --no-build --logger "console;verbosity=normal" && exit 0
-          echo "dotnet test failed; attempting fallback with dotnet vstest..."
-          DLL="tests/Practx.Equipment.Api.Tests/bin/Release/net8.0/Practx.Equipment.Api.Tests.dll"
-          if [ ! -f "$DLL" ]; then
-            echo "Expected test DLL not found at $DLL"
+          ls -la practx-equipment-api/tests/Practx.Equipment.Api.Tests || true
+          ls -la practx-equipment-api/tests/Practx.Equipment.Api.Tests/bin/Release/net8.0 || true
+          cat practx-equipment-api/tests/Practx.Equipment.Api.Tests/Practx.Equipment.Api.Tests.csproj || true
+          if [ ! -f practx-equipment-api/tests/Practx.Equipment.Api.Tests/Practx.Equipment.Api.Tests.csproj ]; then
+            echo "Expected test project not found at practx-equipment-api/tests/Practx.Equipment.Api.Tests/Practx.Equipment.Api.Tests.csproj"
             exit 1
           fi
-          dotnet vstest "$DLL" --Platform:x64 --logger:"console;verbosity=normal"
+
+      - name: Run tests
+        working-directory: .
+        run: |
+          set -euo pipefail
+          dotnet test practx-equipment-api/tests/Practx.Equipment.Api.Tests/Practx.Equipment.Api.Tests.csproj --configuration Release --logger "console;verbosity=normal"
 
       - name: Publish artifact
         run: dotnet publish src/Practx.Equipment.Api/Practx.Equipment.Api.csproj -c Release -o publish


### PR DESCRIPTION
### Motivation
- Ensure the deploy workflow runs test-related diagnostic and test steps from the repository root to avoid broken relative paths.
- Fail early with a clear error when the test project file is missing so CI doesn't proceed with misleading fallbacks.

### Description
- Updated the `Verify test artifacts (diag)` step to run from repo root with `working-directory: .` and to list `practx-equipment-api/tests/Practx.Equipment.Api.Tests` paths.
- Added an explicit existence check for `practx-equipment-api/tests/Practx.Equipment.Api.Tests/Practx.Equipment.Api.Tests.csproj` that exits with an error if missing.
- Updated the `Run tests` step to run `dotnet test practx-equipment-api/tests/Practx.Equipment.Api.Tests/Practx.Equipment.Api.Tests.csproj --configuration Release --logger "console;verbosity=normal"` from the repo root and removed the brittle `dotnet vstest` fallback and `--no-build` usage.
- Added `working-directory: .` to the `Run tests` step so both verification and test execution use the same base path.

### Testing
- No CI workflow run was executed for this workflow-only change.
- No unit or integration tests were run locally as part of this update.
- The change is intended to be validated by running the updated workflow in CI to confirm tests are discovered and executed from the repository root.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69528aa8e85c8323b9d0524ea4d238e9)