### PR TITLE
Use CICD_RG instead of ELM_AZ_RG in equipment API deployment workflow

### DIFF
--- a/.github/workflows/deploy-equipment-api.yml
+++ b/.github/workflows/deploy-equipment-api.yml
@@ -91,7 +91,7 @@ jobs:
     environment:
       name: ${{ vars.ENV_NAME != '' && vars.ENV_NAME || 'DEV' }}
     env:
-      ELM_AZ_RG: ${{ vars.CICD_RG }}
+      CICD_RG: ${{ vars.CICD_RG }}
       ELM_SERVICE_NAME: ${{ vars.ELM_SERVICE_NAME }}
       ELM_APIM_NAME: ${{ vars.ELM_APIM_NAME }}
     defaults:
@@ -112,10 +112,10 @@ jobs:
           subscription-id: ${{ vars.AZURE_SUBSCRIPTION_ID }}
 
       - name: Verify resource group exists
-        run: az group show -n "$ELM_AZ_RG" --query name -o tsv
+        run: az group show -n "$CICD_RG" --query name -o tsv
 
       - name: Verify Function App exists
-        run: az functionapp show -g "$ELM_AZ_RG" -n "$ELM_SERVICE_NAME" --query name -o tsv
+        run: az functionapp show -g "$CICD_RG" -n "$ELM_SERVICE_NAME" --query name -o tsv
 
       - name: Deploy to Function App
         uses: Azure/functions-action@v1
@@ -126,7 +126,7 @@ jobs:
       - name: Resolve service host
         id: resolve-host
         run: |
-          host=$(az functionapp show -g "$ELM_AZ_RG" -n "$ELM_SERVICE_NAME" --query defaultHostName -o tsv)
+          host=$(az functionapp show -g "$CICD_RG" -n "$ELM_SERVICE_NAME" --query defaultHostName -o tsv)
           if [[ -z "$host" ]]; then
             echo "Failed to resolve the Function App hostname" >&2
             exit 1
@@ -137,7 +137,7 @@ jobs:
 
       - name: Validate API Management service
         if: ${{ env.ELM_APIM_NAME != '' }}
-        run: az apim show -g "$ELM_AZ_RG" -n "$ELM_APIM_NAME" --query name -o tsv
+        run: az apim show -g "$CICD_RG" -n "$ELM_APIM_NAME" --query name -o tsv
 
       - name: Import OpenAPI into API Management
         if: ${{ env.ELM_APIM_NAME != '' }}
@@ -146,7 +146,7 @@ jobs:
           az apim api import \
             --path equipment/v1 \
             --api-id equipment-v1 \
-            --resource-group "$ELM_AZ_RG" \
+            --resource-group "$CICD_RG" \
             --service-name "$ELM_APIM_NAME" \
             --specification-format OpenApi \
             --specification-file OpenAPI/openapi.yaml \


### PR DESCRIPTION
### Motivation
- The deployment workflow referenced `ELM_AZ_RG` but the repository uses `CICD_RG` as the canonical resource-group variable.
- Align the equipment API deploy steps with repository variables to avoid confusion and deployment failures.

### Description
- Updated `.github/workflows/deploy-equipment-api.yml` to set `CICD_RG: ${{ vars.CICD_RG }}` in the `deploy` job environment instead of `ELM_AZ_RG`.
- Replaced all runtime references to `ELM_AZ_RG` with `CICD_RG` in `az group show`, `az functionapp show`, `az apim show`, and the `az apim api import` `--resource-group` flag.
- Preserved existing service-name and APIM variables such as `ELM_SERVICE_NAME` and `ELM_APIM_NAME` and left other deployment logic unchanged.

### Testing
- No automated CI workflows were executed as part of this change because it is a workflow-only update.
- Local repository checks confirmed the workflow file was updated and committed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6953d7e0d3e88323bae60021984305e5)