### PR TITLE
Add Equipment CRUD API (SQLite) and wire ELM UI to API

### DIFF
--- a/practx-contracts/openapi/equipment/v1/openapi.yaml
+++ b/practx-contracts/openapi/equipment/v1/openapi.yaml
@@ -35,3 +35,279 @@ paths:
                   version:
                     type: string
                     example: 1.0.0
+  /equipment:
+    get:
+      summary: List equipment
+      tags:
+        - Equipment
+      parameters:
+        - in: query
+          name: search
+          schema:
+            type: string
+          description: Search by asset id, type, or room/space
+        - in: query
+          name: status
+          schema:
+            $ref: '#/components/schemas/EquipmentStatus'
+        - in: query
+          name: sort
+          schema:
+            type: string
+            enum: [spendYtd, nextService]
+        - in: query
+          name: direction
+          schema:
+            type: string
+            enum: [asc, desc]
+        - in: query
+          name: limit
+          schema:
+            type: integer
+            minimum: 1
+            maximum: 200
+        - in: query
+          name: offset
+          schema:
+            type: integer
+            minimum: 0
+      responses:
+        '200':
+          description: A list of equipment assets.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/EquipmentListResponse'
+    post:
+      summary: Create equipment
+      tags:
+        - Equipment
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/EquipmentCreateRequest'
+      responses:
+        '201':
+          description: Equipment created.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/EquipmentResponse'
+        '400':
+          description: Invalid input.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+  /equipment/{id}:
+    get:
+      summary: Get equipment
+      tags:
+        - Equipment
+      parameters:
+        - in: path
+          name: id
+          required: true
+          schema:
+            type: string
+            format: uuid
+      responses:
+        '200':
+          description: Equipment details.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/EquipmentResponse'
+        '404':
+          description: Not found.
+    put:
+      summary: Update equipment
+      tags:
+        - Equipment
+      parameters:
+        - in: path
+          name: id
+          required: true
+          schema:
+            type: string
+            format: uuid
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/EquipmentUpdateRequest'
+      responses:
+        '200':
+          description: Equipment updated.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/EquipmentResponse'
+        '400':
+          description: Invalid input.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        '404':
+          description: Not found.
+    delete:
+      summary: Delete equipment
+      tags:
+        - Equipment
+      parameters:
+        - in: path
+          name: id
+          required: true
+          schema:
+            type: string
+            format: uuid
+      responses:
+        '204':
+          description: Equipment deleted.
+        '404':
+          description: Not found.
+components:
+  schemas:
+    EquipmentStatus:
+      type: string
+      enum: [Unknown, Healthy, Attention, Down, Sunset]
+    EquipmentMonitoringFlags:
+      type: object
+      properties:
+        telemetryEnabled:
+          type: boolean
+        maintenanceAutoCreate:
+          type: boolean
+        safetyAlerts:
+          type: boolean
+      required: [telemetryEnabled, maintenanceAutoCreate, safetyAlerts]
+    EquipmentCreateRequest:
+      type: object
+      properties:
+        assetId:
+          type: string
+        type:
+          type: string
+        location:
+          type: string
+          nullable: true
+        manufacturer:
+          type: string
+          nullable: true
+        model:
+          type: string
+          nullable: true
+        installedDate:
+          type: string
+          format: date
+          nullable: true
+        status:
+          $ref: '#/components/schemas/EquipmentStatus'
+        nextServiceDate:
+          type: string
+          format: date
+          nullable: true
+        monitoringFlags:
+          $ref: '#/components/schemas/EquipmentMonitoringFlags'
+      required: [assetId, type, monitoringFlags]
+    EquipmentUpdateRequest:
+      type: object
+      properties:
+        assetId:
+          type: string
+        type:
+          type: string
+        location:
+          type: string
+          nullable: true
+        manufacturer:
+          type: string
+          nullable: true
+        model:
+          type: string
+          nullable: true
+        installedDate:
+          type: string
+          format: date
+          nullable: true
+        status:
+          $ref: '#/components/schemas/EquipmentStatus'
+        nextServiceDate:
+          type: string
+          format: date
+          nullable: true
+        monitoringFlags:
+          $ref: '#/components/schemas/EquipmentMonitoringFlags'
+      required: [assetId, type, monitoringFlags]
+    EquipmentResponse:
+      type: object
+      properties:
+        id:
+          type: string
+          format: uuid
+        assetId:
+          type: string
+        type:
+          type: string
+        location:
+          type: string
+          nullable: true
+        manufacturer:
+          type: string
+          nullable: true
+        model:
+          type: string
+          nullable: true
+        installedDate:
+          type: string
+          format: date
+          nullable: true
+        status:
+          $ref: '#/components/schemas/EquipmentStatus'
+        nextServiceDate:
+          type: string
+          format: date
+          nullable: true
+        monitoringFlags:
+          $ref: '#/components/schemas/EquipmentMonitoringFlags'
+        spendYearToDate:
+          type: number
+          format: float
+        createdAt:
+          type: string
+          format: date-time
+        updatedAt:
+          type: string
+          format: date-time
+      required:
+        - id
+        - assetId
+        - type
+        - status
+        - monitoringFlags
+        - spendYearToDate
+        - createdAt
+        - updatedAt
+    EquipmentListResponse:
+      type: object
+      properties:
+        items:
+          type: array
+          items:
+            $ref: '#/components/schemas/EquipmentResponse'
+        limit:
+          type: integer
+        offset:
+          type: integer
+        count:
+          type: integer
+      required: [items, limit, offset, count]
+    ErrorResponse:
+      type: object
+      properties:
+        error:
+          type: string

--- a/practx-equipment-api/OpenAPI/openapi.yaml
+++ b/practx-equipment-api/OpenAPI/openapi.yaml
@@ -35,3 +35,279 @@ paths:
                   version:
                     type: string
                     example: 1.0.0
+  /equipment:
+    get:
+      summary: List equipment
+      tags:
+        - Equipment
+      parameters:
+        - in: query
+          name: search
+          schema:
+            type: string
+          description: Search by asset id, type, or room/space
+        - in: query
+          name: status
+          schema:
+            $ref: '#/components/schemas/EquipmentStatus'
+        - in: query
+          name: sort
+          schema:
+            type: string
+            enum: [spendYtd, nextService]
+        - in: query
+          name: direction
+          schema:
+            type: string
+            enum: [asc, desc]
+        - in: query
+          name: limit
+          schema:
+            type: integer
+            minimum: 1
+            maximum: 200
+        - in: query
+          name: offset
+          schema:
+            type: integer
+            minimum: 0
+      responses:
+        '200':
+          description: A list of equipment assets.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/EquipmentListResponse'
+    post:
+      summary: Create equipment
+      tags:
+        - Equipment
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/EquipmentCreateRequest'
+      responses:
+        '201':
+          description: Equipment created.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/EquipmentResponse'
+        '400':
+          description: Invalid input.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+  /equipment/{id}:
+    get:
+      summary: Get equipment
+      tags:
+        - Equipment
+      parameters:
+        - in: path
+          name: id
+          required: true
+          schema:
+            type: string
+            format: uuid
+      responses:
+        '200':
+          description: Equipment details.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/EquipmentResponse'
+        '404':
+          description: Not found.
+    put:
+      summary: Update equipment
+      tags:
+        - Equipment
+      parameters:
+        - in: path
+          name: id
+          required: true
+          schema:
+            type: string
+            format: uuid
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/EquipmentUpdateRequest'
+      responses:
+        '200':
+          description: Equipment updated.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/EquipmentResponse'
+        '400':
+          description: Invalid input.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
+        '404':
+          description: Not found.
+    delete:
+      summary: Delete equipment
+      tags:
+        - Equipment
+      parameters:
+        - in: path
+          name: id
+          required: true
+          schema:
+            type: string
+            format: uuid
+      responses:
+        '204':
+          description: Equipment deleted.
+        '404':
+          description: Not found.
+components:
+  schemas:
+    EquipmentStatus:
+      type: string
+      enum: [Unknown, Healthy, Attention, Down, Sunset]
+    EquipmentMonitoringFlags:
+      type: object
+      properties:
+        telemetryEnabled:
+          type: boolean
+        maintenanceAutoCreate:
+          type: boolean
+        safetyAlerts:
+          type: boolean
+      required: [telemetryEnabled, maintenanceAutoCreate, safetyAlerts]
+    EquipmentCreateRequest:
+      type: object
+      properties:
+        assetId:
+          type: string
+        type:
+          type: string
+        location:
+          type: string
+          nullable: true
+        manufacturer:
+          type: string
+          nullable: true
+        model:
+          type: string
+          nullable: true
+        installedDate:
+          type: string
+          format: date
+          nullable: true
+        status:
+          $ref: '#/components/schemas/EquipmentStatus'
+        nextServiceDate:
+          type: string
+          format: date
+          nullable: true
+        monitoringFlags:
+          $ref: '#/components/schemas/EquipmentMonitoringFlags'
+      required: [assetId, type, monitoringFlags]
+    EquipmentUpdateRequest:
+      type: object
+      properties:
+        assetId:
+          type: string
+        type:
+          type: string
+        location:
+          type: string
+          nullable: true
+        manufacturer:
+          type: string
+          nullable: true
+        model:
+          type: string
+          nullable: true
+        installedDate:
+          type: string
+          format: date
+          nullable: true
+        status:
+          $ref: '#/components/schemas/EquipmentStatus'
+        nextServiceDate:
+          type: string
+          format: date
+          nullable: true
+        monitoringFlags:
+          $ref: '#/components/schemas/EquipmentMonitoringFlags'
+      required: [assetId, type, monitoringFlags]
+    EquipmentResponse:
+      type: object
+      properties:
+        id:
+          type: string
+          format: uuid
+        assetId:
+          type: string
+        type:
+          type: string
+        location:
+          type: string
+          nullable: true
+        manufacturer:
+          type: string
+          nullable: true
+        model:
+          type: string
+          nullable: true
+        installedDate:
+          type: string
+          format: date
+          nullable: true
+        status:
+          $ref: '#/components/schemas/EquipmentStatus'
+        nextServiceDate:
+          type: string
+          format: date
+          nullable: true
+        monitoringFlags:
+          $ref: '#/components/schemas/EquipmentMonitoringFlags'
+        spendYearToDate:
+          type: number
+          format: float
+        createdAt:
+          type: string
+          format: date-time
+        updatedAt:
+          type: string
+          format: date-time
+      required:
+        - id
+        - assetId
+        - type
+        - status
+        - monitoringFlags
+        - spendYearToDate
+        - createdAt
+        - updatedAt
+    EquipmentListResponse:
+      type: object
+      properties:
+        items:
+          type: array
+          items:
+            $ref: '#/components/schemas/EquipmentResponse'
+        limit:
+          type: integer
+        offset:
+          type: integer
+        count:
+          type: integer
+      required: [items, limit, offset, count]
+    ErrorResponse:
+      type: object
+      properties:
+        error:
+          type: string

--- a/practx-equipment-api/src/Practx.Equipment.Api/Data/EquipmentDatabase.cs
+++ b/practx-equipment-api/src/Practx.Equipment.Api/Data/EquipmentDatabase.cs
@@ -1,0 +1,19 @@
+using Microsoft.Data.Sqlite;
+using Microsoft.Extensions.Options;
+
+namespace Practx.Equipment.Api.Data;
+
+public sealed class EquipmentDatabase
+{
+    private readonly EquipmentDatabaseOptions _options;
+
+    public EquipmentDatabase(IOptions<EquipmentDatabaseOptions> options)
+    {
+        _options = options.Value;
+    }
+
+    public SqliteConnection CreateConnection()
+    {
+        return new SqliteConnection(_options.ConnectionString);
+    }
+}

--- a/practx-equipment-api/src/Practx.Equipment.Api/Data/EquipmentDatabaseOptions.cs
+++ b/practx-equipment-api/src/Practx.Equipment.Api/Data/EquipmentDatabaseOptions.cs
@@ -1,0 +1,6 @@
+namespace Practx.Equipment.Api.Data;
+
+public sealed class EquipmentDatabaseOptions
+{
+    public string ConnectionString { get; set; } = "Data Source=equipment.db";
+}

--- a/practx-equipment-api/src/Practx.Equipment.Api/Data/EquipmentMigrationHostedService.cs
+++ b/practx-equipment-api/src/Practx.Equipment.Api/Data/EquipmentMigrationHostedService.cs
@@ -1,0 +1,37 @@
+using System.Text;
+using Microsoft.Extensions.Hosting;
+
+namespace Practx.Equipment.Api.Data;
+
+public sealed class EquipmentMigrationHostedService : IHostedService
+{
+    private readonly EquipmentDatabase _database;
+
+    public EquipmentMigrationHostedService(EquipmentDatabase database)
+    {
+        _database = database;
+    }
+
+    public async Task StartAsync(CancellationToken cancellationToken)
+    {
+        var migrationPath = Path.Combine(AppContext.BaseDirectory, "Migrations", "001_create_equipment.sql");
+        if (!File.Exists(migrationPath))
+        {
+            return;
+        }
+
+        var sql = await File.ReadAllTextAsync(migrationPath, Encoding.UTF8, cancellationToken);
+        if (string.IsNullOrWhiteSpace(sql))
+        {
+            return;
+        }
+
+        await using var connection = _database.CreateConnection();
+        await connection.OpenAsync(cancellationToken);
+        await using var command = connection.CreateCommand();
+        command.CommandText = sql;
+        await command.ExecuteNonQueryAsync(cancellationToken);
+    }
+
+    public Task StopAsync(CancellationToken cancellationToken) => Task.CompletedTask;
+}

--- a/practx-equipment-api/src/Practx.Equipment.Api/Data/IEquipmentRepository.cs
+++ b/practx-equipment-api/src/Practx.Equipment.Api/Data/IEquipmentRepository.cs
@@ -1,0 +1,13 @@
+using Practx.Equipment.Api.Models;
+
+namespace Practx.Equipment.Api.Data;
+
+public interface IEquipmentRepository
+{
+    Task<EquipmentRecord?> GetByIdAsync(Guid id, CancellationToken cancellationToken);
+    Task<EquipmentRecord?> GetByAssetIdAsync(string assetId, CancellationToken cancellationToken);
+    Task<IReadOnlyList<EquipmentRecord>> ListAsync(EquipmentQuery query, CancellationToken cancellationToken);
+    Task<EquipmentRecord> CreateAsync(EquipmentRecord record, CancellationToken cancellationToken);
+    Task<EquipmentRecord> UpdateAsync(EquipmentRecord record, CancellationToken cancellationToken);
+    Task DeleteAsync(Guid id, CancellationToken cancellationToken);
+}

--- a/practx-equipment-api/src/Practx.Equipment.Api/Data/SqliteEquipmentRepository.cs
+++ b/practx-equipment-api/src/Practx.Equipment.Api/Data/SqliteEquipmentRepository.cs
@@ -1,0 +1,229 @@
+using Microsoft.Data.Sqlite;
+using Practx.Equipment.Api.Models;
+
+namespace Practx.Equipment.Api.Data;
+
+public sealed class SqliteEquipmentRepository : IEquipmentRepository
+{
+    private readonly EquipmentDatabase _database;
+
+    public SqliteEquipmentRepository(EquipmentDatabase database)
+    {
+        _database = database;
+    }
+
+    public async Task<EquipmentRecord?> GetByIdAsync(Guid id, CancellationToken cancellationToken)
+    {
+        const string sql = """
+            SELECT id, asset_id, type, location, manufacturer, model, installed_date, status, next_service_date,
+                   monitoring_telemetry, monitoring_maintenance, monitoring_safety, spend_ytd, created_at, updated_at
+            FROM equipment
+            WHERE id = $id
+            LIMIT 1;
+            """;
+
+        await using var connection = _database.CreateConnection();
+        await connection.OpenAsync(cancellationToken);
+        await using var command = connection.CreateCommand();
+        command.CommandText = sql;
+        command.Parameters.AddWithValue("$id", id.ToString());
+        await using var reader = await command.ExecuteReaderAsync(cancellationToken);
+        return await reader.ReadAsync(cancellationToken) ? Map(reader) : null;
+    }
+
+    public async Task<EquipmentRecord?> GetByAssetIdAsync(string assetId, CancellationToken cancellationToken)
+    {
+        const string sql = """
+            SELECT id, asset_id, type, location, manufacturer, model, installed_date, status, next_service_date,
+                   monitoring_telemetry, monitoring_maintenance, monitoring_safety, spend_ytd, created_at, updated_at
+            FROM equipment
+            WHERE asset_id = $assetId
+            LIMIT 1;
+            """;
+
+        await using var connection = _database.CreateConnection();
+        await connection.OpenAsync(cancellationToken);
+        await using var command = connection.CreateCommand();
+        command.CommandText = sql;
+        command.Parameters.AddWithValue("$assetId", assetId);
+        await using var reader = await command.ExecuteReaderAsync(cancellationToken);
+        return await reader.ReadAsync(cancellationToken) ? Map(reader) : null;
+    }
+
+    public async Task<IReadOnlyList<EquipmentRecord>> ListAsync(EquipmentQuery query, CancellationToken cancellationToken)
+    {
+        var conditions = new List<string>();
+        var orderBy = query.SortKey == EquipmentSortKey.NextServiceDate ? "next_service_date" : "spend_ytd";
+        var direction = query.SortDirection == SortDirection.Desc ? "DESC" : "ASC";
+        var limit = Math.Clamp(query.Limit, 1, 200);
+        var offset = Math.Max(query.Offset, 0);
+
+        if (!string.IsNullOrWhiteSpace(query.Search))
+        {
+            conditions.Add("(LOWER(asset_id) LIKE $search OR LOWER(type) LIKE $search OR LOWER(location) LIKE $search)");
+        }
+
+        if (query.Status.HasValue)
+        {
+            conditions.Add("status = $status");
+        }
+
+        var whereClause = conditions.Count > 0 ? $"WHERE {string.Join(" AND ", conditions)}" : string.Empty;
+
+        var sql = $"""
+            SELECT id, asset_id, type, location, manufacturer, model, installed_date, status, next_service_date,
+                   monitoring_telemetry, monitoring_maintenance, monitoring_safety, spend_ytd, created_at, updated_at
+            FROM equipment
+            {whereClause}
+            ORDER BY {orderBy} {direction}
+            LIMIT $limit OFFSET $offset;
+            """;
+
+        var results = new List<EquipmentRecord>();
+        await using var connection = _database.CreateConnection();
+        await connection.OpenAsync(cancellationToken);
+        await using var command = connection.CreateCommand();
+        command.CommandText = sql;
+        command.Parameters.AddWithValue("$limit", limit);
+        command.Parameters.AddWithValue("$offset", offset);
+
+        if (!string.IsNullOrWhiteSpace(query.Search))
+        {
+            command.Parameters.AddWithValue("$search", $"%{query.Search.Trim().ToLowerInvariant()}%");
+        }
+
+        if (query.Status.HasValue)
+        {
+            command.Parameters.AddWithValue("$status", query.Status.Value.ToString());
+        }
+
+        await using var reader = await command.ExecuteReaderAsync(cancellationToken);
+        while (await reader.ReadAsync(cancellationToken))
+        {
+            results.Add(Map(reader));
+        }
+
+        return results;
+    }
+
+    public async Task<EquipmentRecord> CreateAsync(EquipmentRecord record, CancellationToken cancellationToken)
+    {
+        const string sql = """
+            INSERT INTO equipment (
+                id, asset_id, type, location, manufacturer, model, installed_date, status, next_service_date,
+                monitoring_telemetry, monitoring_maintenance, monitoring_safety, spend_ytd, created_at, updated_at
+            ) VALUES (
+                $id, $assetId, $type, $location, $manufacturer, $model, $installedDate, $status, $nextServiceDate,
+                $monitoringTelemetry, $monitoringMaintenance, $monitoringSafety, $spendYtd, $createdAt, $updatedAt
+            );
+            """;
+
+        await using var connection = _database.CreateConnection();
+        await connection.OpenAsync(cancellationToken);
+        await using var command = connection.CreateCommand();
+        command.CommandText = sql;
+        BindParameters(command, record);
+        await command.ExecuteNonQueryAsync(cancellationToken);
+        return record;
+    }
+
+    public async Task<EquipmentRecord> UpdateAsync(EquipmentRecord record, CancellationToken cancellationToken)
+    {
+        const string sql = """
+            UPDATE equipment
+            SET asset_id = $assetId,
+                type = $type,
+                location = $location,
+                manufacturer = $manufacturer,
+                model = $model,
+                installed_date = $installedDate,
+                status = $status,
+                next_service_date = $nextServiceDate,
+                monitoring_telemetry = $monitoringTelemetry,
+                monitoring_maintenance = $monitoringMaintenance,
+                monitoring_safety = $monitoringSafety,
+                spend_ytd = $spendYtd,
+                updated_at = $updatedAt
+            WHERE id = $id;
+            """;
+
+        await using var connection = _database.CreateConnection();
+        await connection.OpenAsync(cancellationToken);
+        await using var command = connection.CreateCommand();
+        command.CommandText = sql;
+        BindParameters(command, record);
+        await command.ExecuteNonQueryAsync(cancellationToken);
+        return record;
+    }
+
+    public async Task DeleteAsync(Guid id, CancellationToken cancellationToken)
+    {
+        const string sql = "DELETE FROM equipment WHERE id = $id;";
+        await using var connection = _database.CreateConnection();
+        await connection.OpenAsync(cancellationToken);
+        await using var command = connection.CreateCommand();
+        command.CommandText = sql;
+        command.Parameters.AddWithValue("$id", id.ToString());
+        await command.ExecuteNonQueryAsync(cancellationToken);
+    }
+
+    private static void BindParameters(SqliteCommand command, EquipmentRecord record)
+    {
+        command.Parameters.AddWithValue("$id", record.Id.ToString());
+        command.Parameters.AddWithValue("$assetId", record.AssetId);
+        command.Parameters.AddWithValue("$type", record.Type);
+        command.Parameters.AddWithValue("$location", record.Location ?? (object)DBNull.Value);
+        command.Parameters.AddWithValue("$manufacturer", record.Manufacturer ?? (object)DBNull.Value);
+        command.Parameters.AddWithValue("$model", record.Model ?? (object)DBNull.Value);
+        command.Parameters.AddWithValue("$installedDate", record.InstalledDate?.ToString("yyyy-MM-dd"));
+        command.Parameters.AddWithValue("$status", record.Status.ToString());
+        command.Parameters.AddWithValue("$nextServiceDate", record.NextServiceDate?.ToString("yyyy-MM-dd"));
+        command.Parameters.AddWithValue("$monitoringTelemetry", record.MonitoringFlags.TelemetryEnabled ? 1 : 0);
+        command.Parameters.AddWithValue("$monitoringMaintenance", record.MonitoringFlags.MaintenanceAutoCreate ? 1 : 0);
+        command.Parameters.AddWithValue("$monitoringSafety", record.MonitoringFlags.SafetyAlerts ? 1 : 0);
+        command.Parameters.AddWithValue("$spendYtd", record.SpendYearToDate);
+        command.Parameters.AddWithValue("$createdAt", record.CreatedAt.ToString("O"));
+        command.Parameters.AddWithValue("$updatedAt", record.UpdatedAt.ToString("O"));
+    }
+
+    private static EquipmentRecord Map(SqliteDataReader reader)
+    {
+        var installedDate = reader["installed_date"] as string;
+        var nextServiceDate = reader["next_service_date"] as string;
+        var createdAt = reader["created_at"] as string;
+        var updatedAt = reader["updated_at"] as string;
+
+        return new EquipmentRecord
+        {
+            Id = Guid.Parse(reader["id"].ToString() ?? string.Empty),
+            AssetId = reader["asset_id"].ToString() ?? string.Empty,
+            Type = reader["type"].ToString() ?? string.Empty,
+            Location = reader["location"] as string,
+            Manufacturer = reader["manufacturer"] as string,
+            Model = reader["model"] as string,
+            InstalledDate = ParseDate(installedDate),
+            Status = Enum.TryParse<EquipmentStatus>(reader["status"].ToString(), out var status)
+                ? status
+                : EquipmentStatus.Unknown,
+            NextServiceDate = ParseDate(nextServiceDate),
+            MonitoringFlags = new EquipmentMonitoringFlags(
+                Convert.ToInt32(reader["monitoring_telemetry"]) == 1,
+                Convert.ToInt32(reader["monitoring_maintenance"]) == 1,
+                Convert.ToInt32(reader["monitoring_safety"]) == 1
+            ),
+            SpendYearToDate = reader["spend_ytd"] == DBNull.Value ? 0 : Convert.ToDecimal(reader["spend_ytd"]),
+            CreatedAt = DateTimeOffset.Parse(createdAt ?? DateTimeOffset.UtcNow.ToString("O")),
+            UpdatedAt = DateTimeOffset.Parse(updatedAt ?? DateTimeOffset.UtcNow.ToString("O")),
+        };
+    }
+
+    private static DateTime? ParseDate(string? raw)
+    {
+        if (string.IsNullOrWhiteSpace(raw))
+        {
+            return null;
+        }
+
+        return DateTime.TryParse(raw, out var value) ? value : null;
+    }
+}

--- a/practx-equipment-api/src/Practx.Equipment.Api/Dtos/EquipmentCreateRequest.cs
+++ b/practx-equipment-api/src/Practx.Equipment.Api/Dtos/EquipmentCreateRequest.cs
@@ -1,0 +1,19 @@
+namespace Practx.Equipment.Api.Dtos;
+
+public sealed record EquipmentCreateRequest(
+    string AssetId,
+    string Type,
+    string? Location,
+    string? Manufacturer,
+    string? Model,
+    DateTime? InstalledDate,
+    string? Status,
+    DateTime? NextServiceDate,
+    EquipmentMonitoringFlagsDto MonitoringFlags
+);
+
+public sealed record EquipmentMonitoringFlagsDto(
+    bool TelemetryEnabled,
+    bool MaintenanceAutoCreate,
+    bool SafetyAlerts
+);

--- a/practx-equipment-api/src/Practx.Equipment.Api/Dtos/EquipmentListResponse.cs
+++ b/practx-equipment-api/src/Practx.Equipment.Api/Dtos/EquipmentListResponse.cs
@@ -1,0 +1,8 @@
+namespace Practx.Equipment.Api.Dtos;
+
+public sealed record EquipmentListResponse(
+    IReadOnlyList<EquipmentResponse> Items,
+    int Limit,
+    int Offset,
+    int Count
+);

--- a/practx-equipment-api/src/Practx.Equipment.Api/Dtos/EquipmentResponse.cs
+++ b/practx-equipment-api/src/Practx.Equipment.Api/Dtos/EquipmentResponse.cs
@@ -1,0 +1,17 @@
+namespace Practx.Equipment.Api.Dtos;
+
+public sealed record EquipmentResponse(
+    Guid Id,
+    string AssetId,
+    string Type,
+    string? Location,
+    string? Manufacturer,
+    string? Model,
+    DateTime? InstalledDate,
+    string Status,
+    DateTime? NextServiceDate,
+    EquipmentMonitoringFlagsDto MonitoringFlags,
+    decimal SpendYearToDate,
+    DateTimeOffset CreatedAt,
+    DateTimeOffset UpdatedAt
+);

--- a/practx-equipment-api/src/Practx.Equipment.Api/Dtos/EquipmentUpdateRequest.cs
+++ b/practx-equipment-api/src/Practx.Equipment.Api/Dtos/EquipmentUpdateRequest.cs
@@ -1,0 +1,13 @@
+namespace Practx.Equipment.Api.Dtos;
+
+public sealed record EquipmentUpdateRequest(
+    string AssetId,
+    string Type,
+    string? Location,
+    string? Manufacturer,
+    string? Model,
+    DateTime? InstalledDate,
+    string? Status,
+    DateTime? NextServiceDate,
+    EquipmentMonitoringFlagsDto MonitoringFlags
+);

--- a/practx-equipment-api/src/Practx.Equipment.Api/Functions/EquipmentFunctions.cs
+++ b/practx-equipment-api/src/Practx.Equipment.Api/Functions/EquipmentFunctions.cs
@@ -1,0 +1,144 @@
+using System.Net;
+using System.Text.Json;
+using Microsoft.Azure.Functions.Worker;
+using Microsoft.Azure.Functions.Worker.Http;
+using Practx.Equipment.Api.Dtos;
+using Practx.Equipment.Api.Services;
+
+namespace Practx.Equipment.Api.Functions;
+
+public sealed class EquipmentFunctions
+{
+    private readonly IEquipmentService _service;
+    private readonly JsonSerializerOptions _serializerOptions;
+
+    public EquipmentFunctions(IEquipmentService service, JsonSerializerOptions serializerOptions)
+    {
+        _service = service;
+        _serializerOptions = serializerOptions;
+    }
+
+    [Function("EquipmentList")]
+    public async Task<HttpResponseData> ListAsync(
+        [HttpTrigger(AuthorizationLevel.Anonymous, "get", Route = "equipment")] HttpRequestData req,
+        CancellationToken cancellationToken)
+    {
+        var query = System.Web.HttpUtility.ParseQueryString(req.Url.Query);
+        var response = await _service.ListAsync(
+            query["search"],
+            query["status"],
+            query["sort"],
+            query["direction"],
+            ParseInt(query["limit"]),
+            ParseInt(query["offset"]),
+            cancellationToken);
+
+        return await WriteJsonAsync(req, HttpStatusCode.OK, response, cancellationToken);
+    }
+
+    [Function("EquipmentGet")]
+    public async Task<HttpResponseData> GetAsync(
+        [HttpTrigger(AuthorizationLevel.Anonymous, "get", Route = "equipment/{id:guid}")] HttpRequestData req,
+        Guid id,
+        CancellationToken cancellationToken)
+    {
+        var response = await _service.GetAsync(id, cancellationToken);
+        if (response is null)
+        {
+            return req.CreateResponse(HttpStatusCode.NotFound);
+        }
+
+        return await WriteJsonAsync(req, HttpStatusCode.OK, response, cancellationToken);
+    }
+
+    [Function("EquipmentCreate")]
+    public async Task<HttpResponseData> CreateAsync(
+        [HttpTrigger(AuthorizationLevel.Anonymous, "post", Route = "equipment")] HttpRequestData req,
+        CancellationToken cancellationToken)
+    {
+        var request = await ReadJsonAsync<EquipmentCreateRequest>(req, cancellationToken);
+        if (request is null)
+        {
+            return req.CreateResponse(HttpStatusCode.BadRequest);
+        }
+
+        try
+        {
+            var response = await _service.CreateAsync(request, cancellationToken);
+            return await WriteJsonAsync(req, HttpStatusCode.Created, response, cancellationToken);
+        }
+        catch (InvalidOperationException ex)
+        {
+            return await WriteErrorAsync(req, HttpStatusCode.BadRequest, ex.Message, cancellationToken);
+        }
+    }
+
+    [Function("EquipmentUpdate")]
+    public async Task<HttpResponseData> UpdateAsync(
+        [HttpTrigger(AuthorizationLevel.Anonymous, "put", Route = "equipment/{id:guid}")] HttpRequestData req,
+        Guid id,
+        CancellationToken cancellationToken)
+    {
+        var request = await ReadJsonAsync<EquipmentUpdateRequest>(req, cancellationToken);
+        if (request is null)
+        {
+            return req.CreateResponse(HttpStatusCode.BadRequest);
+        }
+
+        try
+        {
+            var response = await _service.UpdateAsync(id, request, cancellationToken);
+            if (response is null)
+            {
+                return req.CreateResponse(HttpStatusCode.NotFound);
+            }
+
+            return await WriteJsonAsync(req, HttpStatusCode.OK, response, cancellationToken);
+        }
+        catch (InvalidOperationException ex)
+        {
+            return await WriteErrorAsync(req, HttpStatusCode.BadRequest, ex.Message, cancellationToken);
+        }
+    }
+
+    [Function("EquipmentDelete")]
+    public async Task<HttpResponseData> DeleteAsync(
+        [HttpTrigger(AuthorizationLevel.Anonymous, "delete", Route = "equipment/{id:guid}")] HttpRequestData req,
+        Guid id,
+        CancellationToken cancellationToken)
+    {
+        var deleted = await _service.DeleteAsync(id, cancellationToken);
+        return req.CreateResponse(deleted ? HttpStatusCode.NoContent : HttpStatusCode.NotFound);
+    }
+
+    private async Task<T?> ReadJsonAsync<T>(HttpRequestData req, CancellationToken cancellationToken)
+    {
+        try
+        {
+            return await JsonSerializer.DeserializeAsync<T>(req.Body, _serializerOptions, cancellationToken);
+        }
+        catch (JsonException)
+        {
+            return default;
+        }
+    }
+
+    private async Task<HttpResponseData> WriteJsonAsync(HttpRequestData req, HttpStatusCode status, object payload, CancellationToken cancellationToken)
+    {
+        var response = req.CreateResponse(status);
+        response.Headers.Add("Content-Type", "application/json");
+        await JsonSerializer.SerializeAsync(response.Body, payload, _serializerOptions, cancellationToken);
+        return response;
+    }
+
+    private Task<HttpResponseData> WriteErrorAsync(HttpRequestData req, HttpStatusCode status, string message, CancellationToken cancellationToken)
+    {
+        var payload = new { error = message };
+        return WriteJsonAsync(req, status, payload, cancellationToken);
+    }
+
+    private static int? ParseInt(string? raw)
+    {
+        return int.TryParse(raw, out var value) ? value : null;
+    }
+}

--- a/practx-equipment-api/src/Practx.Equipment.Api/Migrations/001_create_equipment.sql
+++ b/practx-equipment-api/src/Practx.Equipment.Api/Migrations/001_create_equipment.sql
@@ -1,0 +1,21 @@
+CREATE TABLE IF NOT EXISTS equipment (
+    id TEXT PRIMARY KEY,
+    asset_id TEXT NOT NULL UNIQUE,
+    type TEXT NOT NULL,
+    location TEXT NULL,
+    manufacturer TEXT NULL,
+    model TEXT NULL,
+    installed_date TEXT NULL,
+    status TEXT NOT NULL,
+    next_service_date TEXT NULL,
+    monitoring_telemetry INTEGER NOT NULL DEFAULT 0,
+    monitoring_maintenance INTEGER NOT NULL DEFAULT 0,
+    monitoring_safety INTEGER NOT NULL DEFAULT 0,
+    spend_ytd REAL NOT NULL DEFAULT 0,
+    created_at TEXT NOT NULL,
+    updated_at TEXT NOT NULL
+);
+
+CREATE INDEX IF NOT EXISTS idx_equipment_status ON equipment (status);
+CREATE INDEX IF NOT EXISTS idx_equipment_next_service ON equipment (next_service_date);
+CREATE INDEX IF NOT EXISTS idx_equipment_spend_ytd ON equipment (spend_ytd);

--- a/practx-equipment-api/src/Practx.Equipment.Api/Models/EquipmentMonitoringFlags.cs
+++ b/practx-equipment-api/src/Practx.Equipment.Api/Models/EquipmentMonitoringFlags.cs
@@ -1,0 +1,7 @@
+namespace Practx.Equipment.Api.Models;
+
+public sealed record EquipmentMonitoringFlags(
+    bool TelemetryEnabled,
+    bool MaintenanceAutoCreate,
+    bool SafetyAlerts
+);

--- a/practx-equipment-api/src/Practx.Equipment.Api/Models/EquipmentQuery.cs
+++ b/practx-equipment-api/src/Practx.Equipment.Api/Models/EquipmentQuery.cs
@@ -1,0 +1,22 @@
+namespace Practx.Equipment.Api.Models;
+
+public sealed record EquipmentQuery(
+    string? Search,
+    EquipmentStatus? Status,
+    EquipmentSortKey SortKey,
+    SortDirection SortDirection,
+    int Limit,
+    int Offset
+);
+
+public enum EquipmentSortKey
+{
+    SpendYearToDate,
+    NextServiceDate,
+}
+
+public enum SortDirection
+{
+    Asc,
+    Desc,
+}

--- a/practx-equipment-api/src/Practx.Equipment.Api/Models/EquipmentRecord.cs
+++ b/practx-equipment-api/src/Practx.Equipment.Api/Models/EquipmentRecord.cs
@@ -1,0 +1,18 @@
+namespace Practx.Equipment.Api.Models;
+
+public sealed record EquipmentRecord
+{
+    public Guid Id { get; init; }
+    public string AssetId { get; init; } = string.Empty;
+    public string Type { get; init; } = string.Empty;
+    public string? Location { get; init; }
+    public string? Manufacturer { get; init; }
+    public string? Model { get; init; }
+    public DateTime? InstalledDate { get; init; }
+    public EquipmentStatus Status { get; init; }
+    public DateTime? NextServiceDate { get; init; }
+    public EquipmentMonitoringFlags MonitoringFlags { get; init; } = new(false, false, false);
+    public decimal SpendYearToDate { get; init; }
+    public DateTimeOffset CreatedAt { get; init; }
+    public DateTimeOffset UpdatedAt { get; init; }
+}

--- a/practx-equipment-api/src/Practx.Equipment.Api/Models/EquipmentStatus.cs
+++ b/practx-equipment-api/src/Practx.Equipment.Api/Models/EquipmentStatus.cs
@@ -1,0 +1,10 @@
+namespace Practx.Equipment.Api.Models;
+
+public enum EquipmentStatus
+{
+    Unknown = 0,
+    Healthy = 1,
+    Attention = 2,
+    Down = 3,
+    Sunset = 4,
+}

--- a/practx-equipment-api/src/Practx.Equipment.Api/Practx.Equipment.Api.csproj
+++ b/practx-equipment-api/src/Practx.Equipment.Api/Practx.Equipment.Api.csproj
@@ -11,5 +11,11 @@
     <PackageReference Include="Microsoft.Azure.Functions.Worker" Version="1.23.0" />
     <PackageReference Include="Microsoft.Azure.Functions.Worker.Extensions.Http" Version="3.2.0" />
     <PackageReference Include="Microsoft.Azure.Functions.Worker.Sdk" Version="1.17.0" OutputItemType="Analyzer" />
+    <PackageReference Include="Microsoft.Data.Sqlite" Version="8.0.8" />
+    <PackageReference Include="System.Web.HttpUtility" Version="4.7.0" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <Content Include="Migrations/*.sql" CopyToOutputDirectory="PreserveNewest" />
   </ItemGroup>
 </Project>

--- a/practx-equipment-api/src/Practx.Equipment.Api/Program.cs
+++ b/practx-equipment-api/src/Practx.Equipment.Api/Program.cs
@@ -1,7 +1,31 @@
+using System.Text.Json;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
+using Practx.Equipment.Api.Data;
+using Practx.Equipment.Api.Services;
 
 var host = new HostBuilder()
     .ConfigureFunctionsWorkerDefaults()
+    .ConfigureAppConfiguration(builder =>
+    {
+        builder.AddJsonFile("appsettings.json", optional: true, reloadOnChange: true);
+        builder.AddEnvironmentVariables();
+    })
+    .ConfigureServices((context, services) =>
+    {
+        services.Configure<EquipmentDatabaseOptions>(context.Configuration.GetSection("EquipmentDatabase"));
+        services.AddSingleton<EquipmentDatabase>();
+        services.AddSingleton<IEquipmentRepository, SqliteEquipmentRepository>();
+        services.AddSingleton<IEquipmentService, EquipmentService>();
+        services.AddHostedService<EquipmentMigrationHostedService>();
+        services.AddSingleton(new JsonSerializerOptions
+        {
+            PropertyNamingPolicy = JsonNamingPolicy.CamelCase,
+            PropertyNameCaseInsensitive = true,
+            WriteIndented = true,
+        });
+    })
     .Build();
 
 host.Run();

--- a/practx-equipment-api/src/Practx.Equipment.Api/Services/EquipmentService.cs
+++ b/practx-equipment-api/src/Practx.Equipment.Api/Services/EquipmentService.cs
@@ -1,0 +1,249 @@
+using Practx.Equipment.Api.Data;
+using Practx.Equipment.Api.Dtos;
+using Practx.Equipment.Api.Models;
+
+namespace Practx.Equipment.Api.Services;
+
+public sealed class EquipmentService : IEquipmentService
+{
+    private static readonly HashSet<string> AllowedSortKeys = new(StringComparer.OrdinalIgnoreCase)
+    {
+        "spendYtd",
+        "nextService",
+    };
+
+    private static readonly HashSet<string> AllowedDirections = new(StringComparer.OrdinalIgnoreCase)
+    {
+        "asc",
+        "desc",
+    };
+
+    private readonly IEquipmentRepository _repository;
+
+    public EquipmentService(IEquipmentRepository repository)
+    {
+        _repository = repository;
+    }
+
+    public async Task<EquipmentResponse> CreateAsync(EquipmentCreateRequest request, CancellationToken cancellationToken)
+    {
+        var validation = Validate(request.AssetId, request.Type, request.InstalledDate, request.NextServiceDate, request.Status);
+        if (validation is not null)
+        {
+            throw new InvalidOperationException(validation);
+        }
+
+        var existing = await _repository.GetByAssetIdAsync(request.AssetId.Trim(), cancellationToken);
+        if (existing is not null)
+        {
+            throw new InvalidOperationException($"Asset {request.AssetId} already exists.");
+        }
+
+        var now = DateTimeOffset.UtcNow;
+        var monitoringFlags = request.MonitoringFlags ?? new EquipmentMonitoringFlagsDto(false, false, false);
+        var record = new EquipmentRecord
+        {
+            Id = Guid.NewGuid(),
+            AssetId = request.AssetId.Trim(),
+            Type = request.Type.Trim(),
+            Location = NormalizeString(request.Location),
+            Manufacturer = NormalizeString(request.Manufacturer),
+            Model = NormalizeString(request.Model),
+            InstalledDate = request.InstalledDate,
+            Status = ParseStatusOrDefault(request.Status),
+            NextServiceDate = request.NextServiceDate,
+            MonitoringFlags = new EquipmentMonitoringFlags(
+                monitoringFlags.TelemetryEnabled,
+                monitoringFlags.MaintenanceAutoCreate,
+                monitoringFlags.SafetyAlerts
+            ),
+            SpendYearToDate = 0,
+            CreatedAt = now,
+            UpdatedAt = now,
+        };
+
+        await _repository.CreateAsync(record, cancellationToken);
+        return ToResponse(record);
+    }
+
+    public async Task<EquipmentResponse?> GetAsync(Guid id, CancellationToken cancellationToken)
+    {
+        var record = await _repository.GetByIdAsync(id, cancellationToken);
+        return record is null ? null : ToResponse(record);
+    }
+
+    public async Task<EquipmentListResponse> ListAsync(string? search, string? status, string? sort, string? direction, int? limit, int? offset, CancellationToken cancellationToken)
+    {
+        var parsedStatus = ParseStatusFilter(status);
+        var sortKey = ParseSortKey(sort);
+        var sortDirection = ParseSortDirection(direction);
+        var query = new EquipmentQuery(
+            string.IsNullOrWhiteSpace(search) ? null : search,
+            parsedStatus,
+            sortKey,
+            sortDirection,
+            limit ?? 50,
+            offset ?? 0
+        );
+
+        var records = await _repository.ListAsync(query, cancellationToken);
+        var items = records.Select(ToResponse).ToList();
+
+        return new EquipmentListResponse(items, query.Limit, query.Offset, items.Count);
+    }
+
+    public async Task<EquipmentResponse?> UpdateAsync(Guid id, EquipmentUpdateRequest request, CancellationToken cancellationToken)
+    {
+        var validation = Validate(request.AssetId, request.Type, request.InstalledDate, request.NextServiceDate, request.Status);
+        if (validation is not null)
+        {
+            throw new InvalidOperationException(validation);
+        }
+
+        var record = await _repository.GetByIdAsync(id, cancellationToken);
+        if (record is null)
+        {
+            return null;
+        }
+
+        var monitoringFlags = request.MonitoringFlags ?? new EquipmentMonitoringFlagsDto(false, false, false);
+        var updated = record with
+        {
+            AssetId = request.AssetId.Trim(),
+            Type = request.Type.Trim(),
+            Location = NormalizeString(request.Location),
+            Manufacturer = NormalizeString(request.Manufacturer),
+            Model = NormalizeString(request.Model),
+            InstalledDate = request.InstalledDate,
+            Status = ParseStatusOrDefault(request.Status),
+            NextServiceDate = request.NextServiceDate,
+            MonitoringFlags = new EquipmentMonitoringFlags(
+                monitoringFlags.TelemetryEnabled,
+                monitoringFlags.MaintenanceAutoCreate,
+                monitoringFlags.SafetyAlerts
+            ),
+            UpdatedAt = DateTimeOffset.UtcNow,
+        };
+
+        await _repository.UpdateAsync(updated, cancellationToken);
+        return ToResponse(updated);
+    }
+
+    public async Task<bool> DeleteAsync(Guid id, CancellationToken cancellationToken)
+    {
+        var existing = await _repository.GetByIdAsync(id, cancellationToken);
+        if (existing is null)
+        {
+            return false;
+        }
+
+        await _repository.DeleteAsync(id, cancellationToken);
+        return true;
+    }
+
+    private static string? Validate(string assetId, string type, DateTime? installedDate, DateTime? nextServiceDate, string? status)
+    {
+        if (string.IsNullOrWhiteSpace(assetId))
+        {
+            return "AssetId is required.";
+        }
+
+        if (string.IsNullOrWhiteSpace(type))
+        {
+            return "Type is required.";
+        }
+
+        if (installedDate.HasValue && installedDate.Value.Date > DateTime.UtcNow.Date)
+        {
+            return "InstalledDate cannot be in the future.";
+        }
+
+        if (nextServiceDate.HasValue && installedDate.HasValue && nextServiceDate.Value.Date < installedDate.Value.Date)
+        {
+            return "NextServiceDate cannot be before InstalledDate.";
+        }
+
+        if (!string.IsNullOrWhiteSpace(status) && !Enum.TryParse<EquipmentStatus>(status, true, out _))
+        {
+            return $"Status '{status}' is invalid.";
+        }
+
+        return null;
+    }
+
+    private static EquipmentResponse ToResponse(EquipmentRecord record)
+    {
+        return new EquipmentResponse(
+            record.Id,
+            record.AssetId,
+            record.Type,
+            record.Location,
+            record.Manufacturer,
+            record.Model,
+            record.InstalledDate,
+            record.Status.ToString(),
+            record.NextServiceDate,
+            new EquipmentMonitoringFlagsDto(
+                record.MonitoringFlags.TelemetryEnabled,
+                record.MonitoringFlags.MaintenanceAutoCreate,
+                record.MonitoringFlags.SafetyAlerts
+            ),
+            record.SpendYearToDate,
+            record.CreatedAt,
+            record.UpdatedAt
+        );
+    }
+
+    private static EquipmentStatus ParseStatusOrDefault(string? raw)
+    {
+        if (string.IsNullOrWhiteSpace(raw))
+        {
+            return EquipmentStatus.Unknown;
+        }
+
+        return Enum.TryParse<EquipmentStatus>(raw, true, out var parsed) ? parsed : EquipmentStatus.Unknown;
+    }
+
+    private static EquipmentStatus? ParseStatusFilter(string? raw)
+    {
+        if (string.IsNullOrWhiteSpace(raw))
+        {
+            return null;
+        }
+
+        return Enum.TryParse<EquipmentStatus>(raw, true, out var parsed) ? parsed : null;
+    }
+
+    private static EquipmentSortKey ParseSortKey(string? raw)
+    {
+        if (string.IsNullOrWhiteSpace(raw) || !AllowedSortKeys.Contains(raw))
+        {
+            return EquipmentSortKey.SpendYearToDate;
+        }
+
+        return raw.Equals("nextService", StringComparison.OrdinalIgnoreCase)
+            ? EquipmentSortKey.NextServiceDate
+            : EquipmentSortKey.SpendYearToDate;
+    }
+
+    private static SortDirection ParseSortDirection(string? raw)
+    {
+        if (string.IsNullOrWhiteSpace(raw) || !AllowedDirections.Contains(raw))
+        {
+            return SortDirection.Asc;
+        }
+
+        return raw.Equals("desc", StringComparison.OrdinalIgnoreCase) ? SortDirection.Desc : SortDirection.Asc;
+    }
+
+    private static string? NormalizeString(string? value)
+    {
+        if (string.IsNullOrWhiteSpace(value))
+        {
+            return null;
+        }
+
+        var trimmed = value.Trim();
+        return trimmed.Length == 0 ? null : trimmed;
+    }
+}

--- a/practx-equipment-api/src/Practx.Equipment.Api/Services/IEquipmentService.cs
+++ b/practx-equipment-api/src/Practx.Equipment.Api/Services/IEquipmentService.cs
@@ -1,0 +1,12 @@
+using Practx.Equipment.Api.Dtos;
+
+namespace Practx.Equipment.Api.Services;
+
+public interface IEquipmentService
+{
+    Task<EquipmentResponse> CreateAsync(EquipmentCreateRequest request, CancellationToken cancellationToken);
+    Task<EquipmentResponse?> GetAsync(Guid id, CancellationToken cancellationToken);
+    Task<EquipmentListResponse> ListAsync(string? search, string? status, string? sort, string? direction, int? limit, int? offset, CancellationToken cancellationToken);
+    Task<EquipmentResponse?> UpdateAsync(Guid id, EquipmentUpdateRequest request, CancellationToken cancellationToken);
+    Task<bool> DeleteAsync(Guid id, CancellationToken cancellationToken);
+}

--- a/practx-equipment-api/src/Practx.Equipment.Api/appsettings.json
+++ b/practx-equipment-api/src/Practx.Equipment.Api/appsettings.json
@@ -5,5 +5,8 @@
       "Microsoft.AspNetCore": "Warning"
     }
   },
-  "AllowedHosts": "*"
+  "AllowedHosts": "*",
+  "EquipmentDatabase": {
+    "ConnectionString": "Data Source=equipment.db"
+  }
 }

--- a/practx-swa/frontend/equipment/elm-command-center.html
+++ b/practx-swa/frontend/equipment/elm-command-center.html
@@ -638,6 +638,9 @@
   <script>
     const rawData = document.getElementById('mock-data').textContent;
     const state = JSON.parse(rawData);
+    const apiConfig = {
+      baseUrl: '/api/equipment'
+    };
     state.incidents = [];
     const uiState = {
       activeAssetId: null,
@@ -744,6 +747,65 @@
       if (weeks < 5) return `${weeks} wk${weeks > 1 ? 's' : ''} ago`;
       const months = Math.round(days / 30);
       return `${months} mo${months > 1 ? 's' : ''} ago`;
+    }
+
+    function normalizeAsset(asset) {
+      const monitoringFlags = asset.monitoringFlags || {
+        telemetryEnabled: false,
+        maintenanceAutoCreate: false,
+        safetyAlerts: false
+      };
+      return {
+        ...asset,
+        manufacturer: asset.manufacturer || '',
+        installedDate: asset.installedDate || null,
+        monitoringFlags,
+        spend: asset.spend || { ytd: asset.spendYtd || 0, mtd: 0 },
+        forecast: asset.forecast || { '30': 0, '90': 0 },
+        playbook: asset.playbook || [],
+        serviceProviderIds: asset.serviceProviderIds || [],
+        serviceWindowIds: asset.serviceWindowIds || [],
+        history: asset.history || [],
+        trending: asset.trending || generateTrendingFromStatus(asset.status || 'Unknown')
+      };
+    }
+
+    function mapApiAsset(item) {
+      return normalizeAsset({
+        apiId: item.id,
+        id: item.assetId,
+        type: item.type,
+        manufacturer: item.manufacturer || '',
+        model: item.model || '',
+        locationId: item.location || '',
+        installedDate: item.installedDate || null,
+        status: item.status || 'Unknown',
+        nextService: item.nextServiceDate || null,
+        monitoringFlags: item.monitoringFlags || {
+          telemetryEnabled: false,
+          maintenanceAutoCreate: false,
+          safetyAlerts: false
+        },
+        spendYtd: item.spendYearToDate || 0,
+        sunsetDate: item.status === 'Sunset' ? item.updatedAt?.slice(0, 10) : null
+      });
+    }
+
+    async function loadAssetsFromApi() {
+      try {
+        const response = await fetch(`${apiConfig.baseUrl}?sort=spendYtd&direction=desc`);
+        if (!response.ok) {
+          throw new Error(`Equipment API error: ${response.status}`);
+        }
+        const payload = await response.json();
+        if (!payload || !Array.isArray(payload.items)) {
+          return null;
+        }
+        return payload.items.map(mapApiAsset);
+      } catch (error) {
+        console.warn('Unable to load equipment assets from API.', error);
+        return null;
+      }
     }
 
     function buildSparklinePath(values, width = 240, height = 80, padding = 6) {
@@ -1425,13 +1487,16 @@ text-blue-700">
             forecast: { ...existingAsset.forecast },
             playbook: [...(existingAsset.playbook || [])],
             serviceProviderIds: [...(existingAsset.serviceProviderIds || [])],
-            serviceWindowIds: [...(existingAsset.serviceWindowIds || [])]
+            serviceWindowIds: [...(existingAsset.serviceWindowIds || [])],
+            monitoringFlags: { ...existingAsset.monitoringFlags }
           }
         : {
             id: '',
             type: '',
+            manufacturer: '',
             model: '',
             locationId: '',
+            installedDate: '',
             status: 'Healthy',
             nextService: '',
             warranty: '',
@@ -1441,57 +1506,27 @@ text-blue-700">
             playbook: [],
             serviceProviderIds: [],
             serviceWindowIds: [],
+            monitoringFlags: {
+              telemetryEnabled: false,
+              maintenanceAutoCreate: false,
+              safetyAlerts: false
+            },
             sunsetDate: null
           };
       if (existingAsset) {
         uiState.assetDrawer.assetId = existingAsset.id;
       }
       const locations = state.practiceOverview.config.locations;
-      const providers = state.practiceOverview.config.providers;
-      const serviceWindows = state.practiceOverview.config.serviceWindows;
       const statusOptions = ['Healthy', 'Attention', 'Down', 'Unknown', 'Sunset'];
-      const spendYtd = asset.spend?.ytd ?? asset.spendYtd ?? 0;
-      const spendMtd = asset.spend?.mtd ?? 0;
-      const forecast30 = asset.forecast?.['30'] ?? 0;
-      const forecast90 = asset.forecast?.['90'] ?? 0;
-      const playbookValue = asset.playbook.join('\n');
-      const providerList = providers.length
-        ? `<div class="space-y-2">${providers
-            .map((provider) => {
-              const checked = asset.serviceProviderIds.includes(provider.id) ? 'checked' : '';
-              return `<label class="flex items-start gap-3 rounded-2xl border border-slate-200 px-3 py-3 text-sm text-slate-600">
-                <input type="checkbox" name="asset-providers" value="${provider.id}" ${checked} class="mt-1 h-4 w-4 rounded border-slate-300 text-blue-500 focus:ring-blue-200" />
-                <span>
-                  <span class="block font-semibold text-slate-700">${provider.name}</span>
-                  <span class="block text-xs text-slate-400">Priority ${provider.priority} · ${provider.coverage}</span>
-                </span>
-              </label>`;
-            })
-            .join('')}</div>`
-        : '<p class="text-sm text-slate-500">No providers configured.</p>';
-      const windowList = serviceWindows.length
-        ? `<div class="space-y-2">${serviceWindows
-            .map((window) => {
-              const checked = asset.serviceWindowIds.includes(window.id) ? 'checked' : '';
-              return `<label class="flex items-start gap-3 rounded-2xl border border-slate-200 px-3 py-3 text-sm text-slate-600">
-                <input type="checkbox" name="asset-windows" value="${window.id}" ${checked} class="mt-1 h-4 w-4 rounded border-slate-300 text-blue-500 focus:ring-blue-200" />
-                <span>
-                  <span class="block font-semibold text-slate-700">${window.label}</span>
-                  <span class="block text-xs text-slate-400">${window.rrule}</span>
-                </span>
-              </label>`;
-            })
-            .join('')}</div>`
-        : '<p class="text-sm text-slate-500">No service windows configured.</p>';
       const title = isAdd ? 'Add asset' : `Manage ${asset.id}`;
       const subtitle = isAdd
-        ? 'Register equipment and connect it to rooms, providers, and service windows.'
+        ? 'Register equipment and configure monitoring preferences.'
         : `${asset.type || 'Asset'}${asset.model ? ` • ${asset.model}` : ''}`;
       const lifecycleAction = existingAsset
         ? existingAsset.status === 'Sunset'
           ? `<button type="button" data-asset-reactivate class="focus-outline inline-flex items-center gap-2 rounded-full border border-emerald-200 px-4 py-2 text-xs font-semibold text-emerald-700 transition hover:border-emerald-300 hover:bg-emerald-50">Reactivate asset</button>`
           : `<button type="button" data-asset-sunset class="focus-outline inline-flex items-center gap-2 rounded-full border border-rose-200 px-4 py-2 text-xs font-semibold text-rose-600 transition hover:border-rose-300 hover:bg-rose-50">Sunset asset</button>`
-        : '<p class="text-xs text-slate-400">Relationships can be adjusted after you save.</p>';
+        : '<p class="text-xs text-slate-400">Finalize monitoring and service details after you save.</p>';
 
       root.innerHTML = `
         <div class="flex items-start justify-between border-b border-slate-200 px-6 py-5">
@@ -1518,6 +1553,9 @@ text-blue-700">
               <label class="text-sm font-medium text-slate-600">Model
                 <input name="asset-model" value="${asset.model}" class="mt-1 w-full rounded-xl border border-slate-300 px-3 py-2 text-sm text-slate-700 focus:border-blue-500 focus:outline-none focus:ring-2 focus:ring-blue-200" />
               </label>
+              <label class="text-sm font-medium text-slate-600">Manufacturer
+                <input name="asset-manufacturer" value="${asset.manufacturer}" class="mt-1 w-full rounded-xl border border-slate-300 px-3 py-2 text-sm text-slate-700 focus:border-blue-500 focus:outline-none focus:ring-2 focus:ring-blue-200" />
+              </label>
             </section>
 
             <section class="grid gap-4 sm:grid-cols-2">
@@ -1529,6 +1567,9 @@ text-blue-700">
                     .join('')}
                 </select>
               </label>
+              <label class="text-sm font-medium text-slate-600">Installed date
+                <input type="date" name="asset-installed" value="${toDateInputValue(asset.installedDate)}" class="mt-1 w-full rounded-xl border border-slate-300 px-3 py-2 text-sm text-slate-700 focus:border-blue-500 focus:outline-none focus:ring-2 focus:ring-blue-200" />
+              </label>
               <label class="text-sm font-medium text-slate-600">Status
                 <select name="asset-status" class="mt-1 w-full rounded-xl border border-slate-300 px-3 py-2 text-sm text-slate-700 focus:border-blue-500 focus:outline-none focus:ring-2 focus:ring-blue-200">
                   ${statusOptions
@@ -1539,38 +1580,31 @@ text-blue-700">
               <label class="text-sm font-medium text-slate-600">Next service
                 <input type="date" name="asset-next-service" value="${toDateInputValue(asset.nextService)}" class="mt-1 w-full rounded-xl border border-slate-300 px-3 py-2 text-sm text-slate-700 focus:border-blue-500 focus:outline-none focus:ring-2 focus:ring-blue-200" />
               </label>
-              <label class="text-sm font-medium text-slate-600">Warranty expiration
-                <input type="date" name="asset-warranty" value="${toDateInputValue(asset.warranty)}" class="mt-1 w-full rounded-xl border border-slate-300 px-3 py-2 text-sm text-slate-700 focus:border-blue-500 focus:outline-none focus:ring-2 focus:ring-blue-200" />
-              </label>
-            </section>
-
-            <section class="grid gap-4 sm:grid-cols-2">
-              <label class="text-sm font-medium text-slate-600">Spend YTD
-                <input type="number" step="1" min="0" name="asset-spend-ytd" value="${spendYtd}" class="mt-1 w-full rounded-xl border border-slate-300 px-3 py-2 text-sm text-slate-700 focus:border-blue-500 focus:outline-none focus:ring-2 focus:ring-blue-200" />
-              </label>
-              <label class="text-sm font-medium text-slate-600">Spend MTD
-                <input type="number" step="1" min="0" name="asset-spend-mtd" value="${spendMtd}" class="mt-1 w-full rounded-xl border border-slate-300 px-3 py-2 text-sm text-slate-700 focus:border-blue-500 focus:outline-none focus:ring-2 focus:ring-blue-200" />
-              </label>
-              <label class="text-sm font-medium text-slate-600">Forecast 30 days
-                <input type="number" step="1" min="0" name="asset-forecast-30" value="${forecast30}" class="mt-1 w-full rounded-xl border border-slate-300 px-3 py-2 text-sm text-slate-700 focus:border-blue-500 focus:outline-none focus:ring-2 focus:ring-blue-200" />
-              </label>
-              <label class="text-sm font-medium text-slate-600">Forecast 90 days
-                <input type="number" step="1" min="0" name="asset-forecast-90" value="${forecast90}" class="mt-1 w-full rounded-xl border border-slate-300 px-3 py-2 text-sm text-slate-700 focus:border-blue-500 focus:outline-none focus:ring-2 focus:ring-blue-200" />
-              </label>
-            </section>
-
-            <label class="block text-sm font-medium text-slate-600">Playbook steps (one per line)
-              <textarea name="asset-playbook" rows="3" class="mt-1 w-full rounded-xl border border-slate-300 px-3 py-2 text-sm text-slate-700 focus:border-blue-500 focus:outline-none focus:ring-2 focus:ring-blue-200">${playbookValue}</textarea>
-            </label>
-
-            <section class="space-y-3">
-              <h3 class="text-sm font-semibold text-slate-700">Service providers</h3>
-              ${providerList}
             </section>
 
             <section class="space-y-3">
-              <h3 class="text-sm font-semibold text-slate-700">Service windows</h3>
-              ${windowList}
+              <h3 class="text-sm font-semibold text-slate-700">Monitoring preferences</h3>
+              <label class="flex items-start gap-3 rounded-2xl border border-slate-200 px-3 py-3 text-sm text-slate-600">
+                <input type="checkbox" name="asset-telemetry" value="telemetry" ${asset.monitoringFlags?.telemetryEnabled ? 'checked' : ''} class="mt-1 h-4 w-4 rounded border-slate-300 text-blue-500 focus:ring-blue-200" />
+                <span>
+                  <span class="block font-semibold text-slate-700">Realtime telemetry</span>
+                  <span class="block text-xs text-slate-400">Stream live sensor health and usage.</span>
+                </span>
+              </label>
+              <label class="flex items-start gap-3 rounded-2xl border border-slate-200 px-3 py-3 text-sm text-slate-600">
+                <input type="checkbox" name="asset-maintenance" value="maintenance" ${asset.monitoringFlags?.maintenanceAutoCreate ? 'checked' : ''} class="mt-1 h-4 w-4 rounded border-slate-300 text-blue-500 focus:ring-blue-200" />
+                <span>
+                  <span class="block font-semibold text-slate-700">Auto maintenance tickets</span>
+                  <span class="block text-xs text-slate-400">Create work orders when anomalies surface.</span>
+                </span>
+              </label>
+              <label class="flex items-start gap-3 rounded-2xl border border-slate-200 px-3 py-3 text-sm text-slate-600">
+                <input type="checkbox" name="asset-safety" value="safety" ${asset.monitoringFlags?.safetyAlerts ? 'checked' : ''} class="mt-1 h-4 w-4 rounded border-slate-300 text-blue-500 focus:ring-blue-200" />
+                <span>
+                  <span class="block font-semibold text-slate-700">Safety escalation</span>
+                  <span class="block text-xs text-slate-400">Notify reliability team on sterilization variance.</span>
+                </span>
+              </label>
             </section>
 
             <div class="flex flex-col gap-3 border-t border-slate-200 pt-4 sm:flex-row sm:items-center sm:justify-between">
@@ -1668,7 +1702,7 @@ text-blue-700">
       }
     }
 
-    function handleDrawerFormSubmit(event) {
+    async function handleDrawerFormSubmit(event) {
       const form = event.target.closest('form');
       if (!form) return;
       const locationFormKey = form.getAttribute('data-location-form');
@@ -1758,94 +1792,63 @@ text-blue-700">
         const type = (formData.get('asset-type') || '').trim();
         if (!id || !type) return;
         const model = (formData.get('asset-model') || '').trim();
+        const manufacturer = (formData.get('asset-manufacturer') || '').trim();
         const locationId = formData.get('asset-location') || '';
+        const installedRaw = formData.get('asset-installed');
         const status = formData.get('asset-status') || 'Healthy';
         const nextServiceRaw = formData.get('asset-next-service');
-        const warrantyRaw = formData.get('asset-warranty');
-        const spendYtdValue = Number.parseFloat(formData.get('asset-spend-ytd') || '0');
-        const spendMtdValue = Number.parseFloat(formData.get('asset-spend-mtd') || '0');
-        const forecast30Value = Number.parseFloat(formData.get('asset-forecast-30') || '0');
-        const forecast90Value = Number.parseFloat(formData.get('asset-forecast-90') || '0');
-        const playbookRaw = formData.get('asset-playbook') || '';
-        const sanitizeNumber = (value) => (Number.isFinite(value) ? Math.max(0, value) : 0);
-        const spendYtd = sanitizeNumber(spendYtdValue);
-        const spendMtd = sanitizeNumber(spendMtdValue);
-        const forecast30 = sanitizeNumber(forecast30Value);
-        const forecast90 = sanitizeNumber(forecast90Value);
-        const playbook = playbookRaw
-          ? playbookRaw.split(/\n+/).map(item => item.trim()).filter(Boolean)
-          : [];
-        const serviceProviderIds = Array.from(form.querySelectorAll('input[name="asset-providers"]:checked')).map(input => input.value);
-        const serviceWindowIds = Array.from(form.querySelectorAll('input[name="asset-windows"]:checked')).map(input => input.value);
-        const nextService = nextServiceRaw ? nextServiceRaw : null;
-        const warranty = warrantyRaw ? warrantyRaw : null;
+        const monitoringFlags = {
+          telemetryEnabled: formData.get('asset-telemetry') === 'telemetry',
+          maintenanceAutoCreate: formData.get('asset-maintenance') === 'maintenance',
+          safetyAlerts: formData.get('asset-safety') === 'safety'
+        };
+        const payload = {
+          assetId: id,
+          type,
+          location: locationId || null,
+          manufacturer: manufacturer || null,
+          model: model || null,
+          installedDate: installedRaw || null,
+          status,
+          nextServiceDate: nextServiceRaw || null,
+          monitoringFlags
+        };
 
-        if (assetFormKey === 'add') {
-          const newAsset = {
-            id,
-            type,
-            model,
-            locationId: locationId || '',
-            status,
-            nextService,
-            warranty,
-            spendYtd,
-            spend: { ytd: spendYtd, mtd: spendMtd },
-            forecast: { '30': forecast30, '90': forecast90 },
-            playbook,
-            serviceProviderIds,
-            serviceWindowIds,
-            trending: generateTrendingFromStatus(status),
-            history: [],
-            sunsetDate: status === 'Sunset' ? new Date().toISOString().slice(0, 10) : null,
-            previousStatus: status === 'Sunset' ? 'Healthy' : null
-          };
-          state.assets.unshift(newAsset);
-          uiState.assetDrawer = { mode: 'edit', assetId: newAsset.id };
-          uiState.activeAssetId = newAsset.id;
-        } else {
-          const index = state.assets.findIndex(item => item.id === assetFormKey);
-          if (index > -1) {
-            const existing = state.assets[index];
-            const updated = {
-              ...existing,
-              id,
-              type,
-              model,
-              locationId: locationId || '',
-              status,
-              nextService,
-              warranty,
-              spendYtd,
-              spend: { ytd: spendYtd, mtd: spendMtd },
-              forecast: { '30': forecast30, '90': forecast90 },
-              playbook,
-              serviceProviderIds,
-              serviceWindowIds,
-              trending: existing.trending && existing.trending.length ? existing.trending : generateTrendingFromStatus(status),
-              history: existing.history || []
-            };
-            if (existing.status !== 'Sunset' && status === 'Sunset') {
-              updated.previousStatus = existing.status;
-              updated.sunsetDate = new Date().toISOString().slice(0, 10);
-            } else if (status !== 'Sunset') {
-              updated.previousStatus = null;
-              updated.sunsetDate = null;
-            }
-            if (status === 'Sunset' && !updated.sunsetDate) {
-              updated.sunsetDate = new Date().toISOString().slice(0, 10);
-            }
-            state.assets[index] = updated;
-            uiState.assetDrawer.assetId = updated.id;
-            if (uiState.activeAssetId === existing.id) {
-              uiState.activeAssetId = updated.id;
-            }
+        const existing = assetFormKey === 'add' ? null : state.assets.find(item => item.id === assetFormKey);
+        const endpoint = existing?.apiId ? `${apiConfig.baseUrl}/${existing.apiId}` : apiConfig.baseUrl;
+        const method = existing?.apiId ? 'PUT' : 'POST';
+
+        try {
+          const response = await fetch(endpoint, {
+            method,
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify(payload)
+          });
+          if (!response.ok) {
+            const errorPayload = await response.json().catch(() => ({}));
+            throw new Error(errorPayload.error || 'Unable to save asset.');
           }
+          const saved = await response.json();
+          const mapped = mapApiAsset(saved);
+          if (existing) {
+            const index = state.assets.findIndex(item => item.id === existing.id);
+            if (index > -1) {
+              state.assets[index] = { ...existing, ...mapped };
+            } else {
+              state.assets.unshift(mapped);
+            }
+          } else {
+            state.assets.unshift(mapped);
+          }
+          uiState.assetDrawer = { mode: 'edit', assetId: mapped.id };
+          uiState.activeAssetId = mapped.id;
+          renderAssets();
+          renderAssetDetail();
+          showToast(`${mapped.id} saved`);
+          closeDrawer('asset-management');
+        } catch (error) {
+          showToast(error.message || 'Unable to save asset.');
         }
-        renderAssets();
-        renderAssetDetail();
-        showToast(`${id} saved`);
-        closeDrawer('asset-management');
       }
     }
 
@@ -1966,7 +1969,7 @@ text-blue-700">
       });
     }
 
-    function initialize() {
+    async function initialize() {
       refs.practiceName = document.getElementById('practice-name');
       refs.practiceName.textContent = state.practiceOverview.practiceName;
       refs.lastRefreshed = document.getElementById('last-refreshed');
@@ -1976,6 +1979,11 @@ text-blue-700">
         hour: 'numeric',
         minute: '2-digit'
       });
+      state.assets = state.assets.map(normalizeAsset);
+      const apiAssets = await loadAssetsFromApi();
+      if (apiAssets && apiAssets.length) {
+        state.assets = apiAssets;
+      }
       renderKPIs();
       renderTrends();
       renderAssets();


### PR DESCRIPTION
### Motivation
- Provide a first-class Equipment CRUD surface that mirrors the ELM mock UI fields (asset id, type, location, manufacturer, model, installed date, status, next service, monitoring flags). 
- Define DTOs and an API contract so the web mock can be wired to a real backend and clients can rely on a stable schema. 
- Support list/search/filter/sort semantics used by the UI (search by asset/type/room, filter by status, sort by spend/next service). 
- Persist equipment data with a lightweight schema and migrations so service startup can provision storage.

### Description
- Added API surface and contracts: new OpenAPI definitions (`/equipment` endpoints) and server DTOs under `src/.../Dtos` (`EquipmentCreateRequest`, `EquipmentUpdateRequest`, `EquipmentResponse`, `EquipmentListResponse`, monitoring flags DTO). 
- Implemented domain models, repository and data layer: `EquipmentRecord`, `EquipmentStatus`, `EquipmentMonitoringFlags`, `EquipmentQuery`, `SqliteEquipmentRepository`, `EquipmentDatabase` and `EquipmentDatabaseOptions`, plus SQL migration `Migrations/001_create_equipment.sql`. 
- Service and endpoints: `IEquipmentService` and `EquipmentService` with validation and mapping logic, and Azure Functions handlers in `Functions/EquipmentFunctions.cs` for list/get/create/update/delete. 
- App wiring and UI updates: service registration and migrations run on startup in `Program.cs`, `appsettings.json` DB config, and ELM mock UI `elm-command-center.html` updated to surface `manufacturer`, `installedDate`, monitoring preferences and to load/save assets from the API via a small client layer.

### Testing
- Automated tests: none executed for this change (no unit/integration tests were run as part of the rollout). 
- Migrations: a migration script `001_create_equipment.sql` was added and is included in the function project output so it runs at service startup via a hosted service. 
- Local UI integration: the front-end was adapted to call the new API contract, but no automated end-to-end tests were executed. 
- CI/test matrix: no CI test job was triggered as part of this change in the workspace; existing diagnostics endpoints remain unchanged.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6953dc188468832392d734ba1006a437)