### PR TITLE
Use spectral:oas ruleset to fix equipment API OpenAPI lint

### DIFF
--- a/practx-equipment-api/.spectral.yaml
+++ b/practx-equipment-api/.spectral.yaml
@@ -1,2 +1,2 @@
 extends:
-  - "./node_modules/@stoplight/spectral-rulesets/dist/oas/index.js"
+  - "spectral:oas"


### PR DESCRIPTION
### Motivation
- Spectral was crashing during OpenAPI lint with `Function "oasDocumentSchema" threw an exception`, and simply disabling the `oas3-schema` rule removed validation rather than addressing the cause. 
- The goal is to keep schema validation enabled while avoiding the runtime exception that breaks CI. 
- Using the packaged, built-in ruleset can avoid fragile local path resolution or version mismatch issues. 

### Description
- Updated `practx-equipment-api/.spectral.yaml` to extend the built-in ruleset by replacing the file-system path with `spectral:oas`. 
- This change preserves OpenAPI schema validation rules while avoiding the `oasDocumentSchema` runtime crash. 
- No other repository files were modified in this change. 

### Testing
- Running `npm run lint:openapi` before the change produced the Spectral crash (`oasDocumentSchema` threw an exception). 
- After updating `practx-equipment-api/.spectral.yaml`, `npm run lint:openapi` completes successfully and reports 24 warnings (no errors). 
- All automated lint runs in the workspace used to validate this change exited with success after the update.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6953e72989948323b77c65462282f7d1)